### PR TITLE
fix(blog): mobile touch panning, full-bleed overflow, footer spacing

### DIFF
--- a/src/app/blog/a-test-bench-i-can-rely-on/page.tsx
+++ b/src/app/blog/a-test-bench-i-can-rely-on/page.tsx
@@ -426,7 +426,11 @@ export default function TestBenchPage() {
         <PostFooterNav slug="a-test-bench-i-can-rely-on" />
       </Container>
 
-      <Footer />
+      {/* The shared footer bleeds its logo to the page bottom, which reads as
+          design on the landing page and as a cut-off page under an article. */}
+      <Box pb={{ base: 10, md: 16 }}>
+        <Footer />
+      </Box>
     </Box>
   );
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -85,7 +85,11 @@ export default function BlogIndexPage() {
           ))}
         </VStack>
       </Container>
-      <Footer />
+      {/* The shared footer bleeds its logo to the page bottom, which reads as
+          design on the landing page and as a cut-off page under an article. */}
+      <Box pb={{ base: 10, md: 16 }}>
+        <Footer />
+      </Box>
     </Box>
   );
 }

--- a/src/app/blog/the-robotic-workshop/page.tsx
+++ b/src/app/blog/the-robotic-workshop/page.tsx
@@ -329,7 +329,11 @@ export default function TheRoboticWorkshopPage() {
         <PostFooterNav slug="the-robotic-workshop" />
       </Container>
 
-      <Footer />
+      {/* The shared footer bleeds its logo to the page bottom, which reads as
+          design on the landing page and as a cut-off page under an article. */}
+      <Box pb={{ base: 10, md: 16 }}>
+        <Footer />
+      </Box>
     </Box>
   );
 }

--- a/src/components/Blog/WorkshopChart.tsx
+++ b/src/components/Blog/WorkshopChart.tsx
@@ -122,6 +122,13 @@ export default function WorkshopChart() {
 
   useEffect(() => {
     const measure = () => {
+      // The width the chart bleeds to. documentElement.clientWidth excludes the
+      // scrollbar, which 100vw would wrongly include and overflow the page by.
+      document.documentElement.style.setProperty(
+        "--bleed-w",
+        `${document.documentElement.clientWidth}px`
+      );
+
       const marker = alignRef.current;
       const canvas = canvasRef.current;
       if (!marker || !canvas) return;
@@ -715,14 +722,19 @@ export default function WorkshopChart() {
            never arbitrated here and always scrolls the page. */
         overflow="hidden"
         cursor="grab"
-        touchAction="pan-y"
+        /* Vertical touch still scrolls the page. Horizontal is left to the drag
+           handler, which "pan-y" alone would stop the browser from delivering. */
+        touchAction="pan-y pinch-zoom"
         backgroundImage="radial-gradient(circle at 1px 1px, rgba(26,26,26,.10) 1px, transparent 0)"
         backgroundSize="22px 22px"
         h={{ base: "460px", md: "620px" }}
-        /* Break out of the article's text column to the full viewport width. */
-        w="100vw"
-        ml="calc(50% - 50vw)"
-        mr="calc(50% - 50vw)"
+        /* Break out of the article's text column to the full viewport width.
+           Widths come from the root element, not 100vw, because vw counts the
+           scrollbar while the page content box does not, and the difference
+           makes the page itself scroll sideways. */
+        w="var(--bleed-w, 100vw)"
+        ml="calc(50% - var(--bleed-w, 100vw) / 2)"
+        mr="calc(50% - var(--bleed-w, 100vw) / 2)"
         px={`${gutter}px`}
       >
         <svg


### PR DESCRIPTION
Follow-up to #39. Three fixes that landed after that PR was merged.

## 1. The chart could not be panned on a touch device

The chart container had `touch-action: pan-y`. That reserves vertical scrolling for the browser and leaves the element with **no** horizontal gesture, so a sideways swipe never reached the drag handler. Combined with `overflow: hidden`, the chart was a fixed window onto a 2,700px-wide diagram with no way to move it. At desktop width 1,357px was already off screen. On a phone it is closer to 2,200px.

Now `touch-action: pan-y pinch-zoom`. Vertical touch still scrolls the page. Horizontal reaches the handler.

## 2. The page scrolled sideways by the scrollbar width

The full-bleed chart used `w="100vw"`. `100vw` includes the scrollbar, while the page content box does not, so the chart was 15px wider than the viewport on desktop and the whole page scrolled horizontally.

Width now comes from `documentElement.clientWidth` through a `--bleed-w` custom property, set in the resize effect that already runs. A `100vw` fallback covers first paint before the effect fires.

Verified: frame width 1348px against a content width of 1348px, and no horizontal document overflow.

## 3. Footer logo sat flush against the page bottom

The shared `Footer` has `padding-bottom: 0`, so its 500px logo bleeds to the bottom edge. That reads as design on the landing page and as a cut-off page under an article. Blog pages now wrap the footer in a `Box` with bottom padding. The landing page is untouched, confirmed by measuring both.

## Testing notes

`resize_window` reports success but does not change the viewport in this environment, so I could not render a genuine narrow layout. The bleed math was instead verified in a detached replica of the same CSS relationship at 390px, 768px and 1348px, all fitting exactly.

An earlier simulation suggested a 122px overflow at mobile width. That was an artifact of resizing the live container, which breaks the `calc(50% - ...)` margins that resolve against the parent. There is no such overflow.

**The touch behaviour needs a real device.** Nothing in this environment can send a genuine touch gesture.

## Checks

- `tsc --noEmit` clean
- `next lint` clean
- `next build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAkVCivNLfXnRBHmxfnppo