### PR TITLE
How section: full-width demo cards on phones

### DIFF
--- a/src/components/Landing/HowSection.tsx
+++ b/src/components/Landing/HowSection.tsx
@@ -116,7 +116,10 @@ export default function HowSection() {
                   w={{ base: "100%", md: "50%" }}
                   position="relative"
 
-                  p={{ base: 2, md: 10, lg: 12 }}
+                  /* Phones have no wireframe grid behind the card, so no
+                     decorative inset either — the card spans the same width
+                     as the text column (page margins only). */
+                  p={{ base: 0, md: 10, lg: 12 }}
                   borderRadius="20px"
                 >
                   {/* Neat animated gradient behind card */}


### PR DESCRIPTION
On mobile the wireframe grid behind the How-section cards no longer renders, so the decorative padding around the cards just made them narrower than the text for no reason. This drops that inset at the base breakpoint so the cards span the same width as the text column (page margins only). Desktop unchanged.

Verified: card left edge measures 16px, identical to the headline's; no horizontal scroll; typecheck, lint, and 65/65 tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gCGsXe7FDzkTWGZ9HJMfg