### PR TITLE
Demo animations: never-empty choreography, brand palette, richer stories

### DIFF
--- a/src/components/Landing/ConnectDemo.tsx
+++ b/src/components/Landing/ConnectDemo.tsx
@@ -9,12 +9,12 @@ import { MotionBox, DemoContainer } from "./demo-primitives";
 
 const INTEGRATIONS = [
   { key: "slack", letter: "S", name: "Slack", color: "#E01E5A" },
-  { key: "email", letter: "E", name: "Email (SMTP)", color: "#3B82F6" },
+  { key: "email", letter: "E", name: "Email (SMTP)", color: "#DFAEC0" },
   { key: "sheets", letter: "G", name: "Google Sheets", color: "#34A853" },
 ] as const;
 
 const ACTIVITY_ITEMS = [
-  { text: "Quote received from MSC", dot: "#3B82F6", time: "just now" },
+  { text: "Quote received from MSC", dot: "#DFAEC0", time: "just now" },
   { text: "Slack alert sent to #freight", dot: "#E01E5A", time: "2s ago" },
 ];
 
@@ -27,6 +27,12 @@ const ACTIVITY_STAGGER = 500;
 const END_PAUSE = 1200;
 
 type IntegrationStatus = "hidden" | "connecting" | "connected";
+
+// The panel must never open on a bare box: the first mounted frame (and every
+// loop reset, since resets crossfade back to this same state) already shows
+// the CONNECTIONS header with Slack connected, so there's always a populated
+// row on screen while Email/Sheets stage in behind it.
+const INITIAL_STATUSES: IntegrationStatus[] = ["connected", "hidden", "hidden"];
 
 // ── Sub-components ──
 
@@ -91,12 +97,12 @@ function IntegrationRow({
       gap={3}
       bg="rgba(255,255,255,0.06)"
       border="1px solid rgba(255,255,255,0.12)"
-      borderRadius="8px"
-      px={3}
-      py={2.5}
+      borderRadius="10px"
+      px={4}
+      py={{ base: 4, md: 2.5 }}
     >
       <IntegrationIcon letter={letter} bg={iconColor} />
-      <Text fontSize="sm" color="#F8F7F4" fontWeight="500" flex="1">
+      <Text fontSize="sm" fontFamily="heading" color="#F8F7F4" fontWeight="600" flex="1">
         {name}
       </Text>
       {status === "connecting" && (
@@ -169,11 +175,7 @@ function ActivityItem({
 // ── Main component ──
 
 export function ConnectDemo() {
-  const [statuses, setStatuses] = useState<IntegrationStatus[]>([
-    "hidden",
-    "hidden",
-    "hidden",
-  ]);
+  const [statuses, setStatuses] = useState<IntegrationStatus[]>(INITIAL_STATUSES);
   const [showActivity, setShowActivity] = useState(false);
   const [cycle, setCycle] = useState(0);
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -189,14 +191,18 @@ export function ConnectDemo() {
 
   useEffect(() => {
     clearTimers();
-    setStatuses(["hidden", "hidden", "hidden"]);
+    // Slack starts pre-connected (see INITIAL_STATUSES) so the very first
+    // frame already has a populated row — only Email and Sheets animate in.
+    setStatuses(INITIAL_STATUSES);
     setShowActivity(false);
 
     const t = 0;
+    const remaining = INTEGRATIONS.slice(1);
 
-    // For each integration: appear as connecting, then switch to connected
-    INTEGRATIONS.forEach((_, i) => {
-      const appearAt = t + i * (CONNECTING_DURATION + INTER_CARD_GAP) + CARD_APPEAR_DELAY;
+    // For each remaining integration: appear as connecting, then switch to connected
+    remaining.forEach((_, ri) => {
+      const i = ri + 1;
+      const appearAt = t + ri * (CONNECTING_DURATION + INTER_CARD_GAP) + CARD_APPEAR_DELAY;
 
       // Show as connecting
       addTimer(() => {
@@ -220,7 +226,7 @@ export function ConnectDemo() {
     // Calculate when all integrations are connected
     const allConnectedAt =
       CARD_APPEAR_DELAY +
-      INTEGRATIONS.length * (CONNECTING_DURATION + INTER_CARD_GAP) -
+      remaining.length * (CONNECTING_DURATION + INTER_CARD_GAP) -
       INTER_CARD_GAP +
       CONNECTING_DURATION;
 
@@ -258,6 +264,7 @@ export function ConnectDemo() {
           transition={{ duration: 0.3 }}
           display="flex"
           flexDirection="column"
+          justifyContent="center"
           h="100%"
         >
           {/* Header */}
@@ -271,13 +278,18 @@ export function ConnectDemo() {
             >
               Connections
             </Text>
-            <Text fontSize="xs" color="rgba(255,255,255,0.5)" fontWeight="500">
+            <Text
+              fontSize="xs"
+              color="rgba(255,255,255,0.5)"
+              fontWeight="500"
+              fontVariantNumeric="tabular-nums"
+            >
               {connectedCount} active
             </Text>
           </Flex>
 
           {/* Integration rows */}
-          <Flex direction="column" gap={2} mb={4}>
+          <Flex direction="column" gap={{ base: 4, md: 2 }} mb={4}>
             <AnimatePresence>
               {INTEGRATIONS.map((intg, i) =>
                 statuses[i] !== "hidden" ? (
@@ -293,7 +305,10 @@ export function ConnectDemo() {
             </AnimatePresence>
           </Flex>
 
-          {/* Activity feed */}
+          {/* Activity feed — the whole column is vertically centered (see
+              justifyContent="center" above), so this no longer needs to pin
+              itself to the bottom with mt="auto"; that avoided a stranded
+              void between the rows and a bottom-pinned feed. */}
           <AnimatePresence>
             {showActivity && (
               <MotionBox
@@ -301,7 +316,6 @@ export function ConnectDemo() {
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.3 }}
-                mt="auto"
               >
                 <Flex align="center" gap={1.5} mb={2}>
                   <PulsingDot color="#10B981" />

--- a/src/components/Landing/GetDemos.tsx
+++ b/src/components/Landing/GetDemos.tsx
@@ -18,28 +18,34 @@ const C = {
   pillText: "rgba(255,255,255,0.8)",
   green: "#10B981",
   amber: "#F59E0B",
-  blue: "#3B82F6",
+  accent: "#DFAEC0", // dusty rose brand accent (replaces generic SaaS blue on dark grounds)
   cardBg: "rgba(255,255,255,0.06)",
 };
 
-/** Hook: phase-based animation loop with cleanup */
+/**
+ * Hook: phase-based animation loop with cleanup.
+ * `initialPhase` is the phase the panel mounts in AND the phase a loop
+ * reset falls back to — it should already be a populated mid-story frame
+ * so the card is never caught empty (first paint or reset alike).
+ */
 function usePhaseLoop(
   schedule: Array<{ ms: number; phase: number }>,
-  resetMs: number
+  resetMs: number,
+  initialPhase = 0
 ) {
-  const [phase, setPhase] = useState(0);
+  const [phase, setPhase] = useState(initialPhase);
   const [cycle, setCycle] = useState(0);
 
   useEffect(() => {
     const timeouts: ReturnType<typeof setTimeout>[] = [];
-    setPhase(0);
+    setPhase(initialPhase);
 
     for (const s of schedule) {
       timeouts.push(setTimeout(() => setPhase(s.phase), s.ms));
     }
     timeouts.push(
       setTimeout(() => {
-        setPhase(0);
+        setPhase(initialPhase);
         setCycle((c) => c + 1);
       }, resetMs)
     );
@@ -60,18 +66,19 @@ const formFields = [
 ];
 
 export function SimpleInterfaceDemo() {
-  // 0=empty, 1=progress+goal, 2=field1, 3=field2, 4=field3, 5=button, 6=progress-update, 7=pause
+  // 0=empty (unused — never mounted), 1=progress+goal, 2=field1, 3=field2, 4=field3, 5=button, 6=progress-update, 7=pause
+  // Mounts (and loop-resets) at phase 2: progress bar + first field already on screen,
+  // so the panel is never caught as a bare box.
   const phase = usePhaseLoop(
     [
-      { ms: 300, phase: 1 },
-      { ms: 900, phase: 2 },
-      { ms: 1500, phase: 3 },
-      { ms: 2100, phase: 4 },
-      { ms: 3000, phase: 5 },
-      { ms: 4200, phase: 6 },
-      { ms: 5800, phase: 7 },
+      { ms: 600, phase: 3 },
+      { ms: 1200, phase: 4 },
+      { ms: 2100, phase: 5 },
+      { ms: 3300, phase: 6 },
+      { ms: 4900, phase: 7 },
     ],
-    7500
+    6400,
+    2
   );
 
   return (
@@ -90,12 +97,12 @@ export function SimpleInterfaceDemo() {
             >
               <Flex align="center" justify="space-between" mb={2}>
                 <Flex align="center" gap={2}>
-                  <Box w="8px" h="8px" borderRadius="full" bg={C.blue} />
-                  <Text fontSize="md" fontWeight="600" color={C.text}>
+                  <Box w="8px" h="8px" borderRadius="full" bg={C.accent} />
+                  <Text fontSize="md" fontFamily="heading" fontWeight="600" color={C.text}>
                     Lane Defined
                   </Text>
                 </Flex>
-                <Text fontSize="xs" color={C.muted} fontWeight="600">
+                <Text fontSize="xs" color={C.muted} fontWeight="600" fontVariantNumeric="tabular-nums">
                   {phase >= 6 ? "1/2" : "0/2"}
                 </Text>
               </Flex>
@@ -281,6 +288,9 @@ export function RewindDemo() {
       return "pending";
     }
     if (key === "bol") {
+      // The cascade un-does downstream work too — a later step can never
+      // stay "done" while an earlier one has been reopened.
+      if (phase >= 5) return "pending";
       if (phase >= 3) return "done";
       return "pending";
     }
@@ -289,12 +299,12 @@ export function RewindDemo() {
 
   return (
     <DemoContainer variant="maroon" flush>
-      <Flex direction="column" h="100%" gap={0}>
+      <Flex direction="column" h="100%" gap={0} justify="center">
         {/* Goal header with count */}
         <Flex justify="space-between" align="center" mb={3}>
           <Flex align="center" gap={2}>
-            <Box w="8px" h="8px" borderRadius="full" bg={C.blue} />
-            <Text fontSize="sm" fontWeight="600" color={C.text}>
+            <Box w="8px" h="8px" borderRadius="full" bg={C.accent} />
+            <Text fontSize="sm" fontFamily="heading" fontWeight="600" color={C.text}>
               Shipment Cleared
             </Text>
           </Flex>
@@ -307,8 +317,8 @@ export function RewindDemo() {
                 exit={{ opacity: 0 }}
                 transition={{ type: "spring", stiffness: 400, damping: 20 }}
               >
-                <Text fontSize="xs" color={C.amber} fontWeight="600">
-                  {phase >= 5 ? "1/3" : "2/3"}
+                <Text fontSize="xs" color={C.amber} fontWeight="600" fontVariantNumeric="tabular-nums">
+                  {phase >= 5 ? "0/3" : "2/3"}
                 </Text>
               </MotionBox>
             ) : (
@@ -318,7 +328,7 @@ export function RewindDemo() {
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
               >
-                <Text fontSize="xs" color={C.muted} fontWeight="600">
+                <Text fontSize="xs" color={C.muted} fontWeight="600" fontVariantNumeric="tabular-nums">
                   {phase >= 3 ? "3/3" : phase >= 2 ? "2/3" : phase >= 1 ? "1/3" : "0/3"}
                 </Text>
               </MotionBox>
@@ -326,8 +336,10 @@ export function RewindDemo() {
           </AnimatePresence>
         </Flex>
 
-        {/* Check tree with vertical connectors */}
-        <Box flex="1" position="relative">
+        {/* Check tree with vertical connectors — no flex-grow: growing this
+            box pushed the cascade toast to the panel bottom and opened a
+            dead gap under the three-item tree on desktop heights. */}
+        <Box position="relative">
           {/* Vertical connector line */}
           <Box
             position="absolute"
@@ -490,7 +502,11 @@ export function AuditDemo() {
 
   return (
     <DemoContainer variant="maroon" flush>
-      <Flex direction="column" h="100%" gap={0}>
+      {/* justify="center" keeps this small, fixed-content demo (header + 2
+          rules, occasionally + version badge/audit line) as one centered
+          mass in the panel instead of pinned to the top with a growing void
+          below it. */}
+      <Flex direction="column" justify="center" h="100%" gap={0}>
         {/* Section header — check editor style */}
         <Flex justify="space-between" align="center" mb={3}>
           <Text
@@ -513,7 +529,7 @@ export function AuditDemo() {
         </Flex>
 
         {/* Rule 1: pill tokens */}
-        <Box flex="1">
+        <Box>
           <Box
             mb={3}
             px={3}
@@ -542,12 +558,12 @@ export function AuditDemo() {
             py={2.5}
             bg={C.cardBg}
             border="1px solid"
-            borderColor={phase >= 1 ? "rgba(59,130,246,0.4)" : C.border}
+            borderColor={phase >= 1 ? "rgba(223,174,192,0.5)" : C.border}
             borderRadius="8px"
             transition="border-color 0.3s"
             boxShadow={
               phase >= 1 && phase < 3
-                ? "0 0 0 1px rgba(59,130,246,0.2)"
+                ? "0 0 0 1px rgba(223,174,192,0.25)"
                 : "none"
             }
           >
@@ -669,18 +685,18 @@ export function AuditDemo() {
 const autoSteps = ["Parse input", "Fetch rates", "Score match"];
 
 export function HumanJudgementDemo() {
-  // 0=idle, 1=step1, 2=step2, 3=step3-done, 4=approval-section, 5=reviewing, 6=approved, 7=pause
+  // 0-2=idle/step1/step2 (unused — never mounted), 3=step3-done, 4=approval-section, 5=reviewing, 6=approved, 7=pause
+  // Mounts (and loop-resets) at phase 3: all three auto steps already complete,
+  // so the panel opens with real content rather than an empty box.
   const phase = usePhaseLoop(
     [
-      { ms: 300, phase: 1 },
-      { ms: 800, phase: 2 },
-      { ms: 1300, phase: 3 },
-      { ms: 2200, phase: 4 },
-      { ms: 3400, phase: 5 },
-      { ms: 5000, phase: 6 },
-      { ms: 6200, phase: 7 },
+      { ms: 900, phase: 4 },
+      { ms: 2100, phase: 5 },
+      { ms: 3700, phase: 6 },
+      { ms: 4900, phase: 7 },
     ],
-    7800
+    6300,
+    3
   );
 
   return (

--- a/src/components/Landing/HeroDemo.tsx
+++ b/src/components/Landing/HeroDemo.tsx
@@ -7,7 +7,7 @@ import { MotionBox, StatusBadge, TypingCursor } from "./demo-primitives";
 
 // ── Constants ──
 const REQUEST_TEXT = "Every new shipping inquiry needs three carrier quotes, the cheapest flagged, and an RFQ sent to the client";
-const TYPING_SPEED = 35; // ms per character
+const TYPING_SPEED = 10; // ms per character
 const CHECKS = [
   "At least 3 carrier quotes collected",
   "Lowest rate identified and flagged",
@@ -38,8 +38,12 @@ type Phase =
   | "fade-out";
 
 export default function HeroDemo() {
-  const [phase, setPhase] = useState<Phase>("typing");
-  const [typedChars, setTypedChars] = useState(0);
+  // Mid-story start: the first visible frame is "complete" — the goal card
+  // is already fully populated (all checks ticked, status Processed) —
+  // rather than an empty card waiting for typing. The request field types
+  // out on top of/above that still-visible prior result each loop.
+  const [phase, setPhase] = useState<Phase>("complete");
+  const [typedChars, setTypedChars] = useState(REQUEST_TEXT.length);
 
   const schedule = useCallback(
     (timeouts: NodeJS.Timeout[], fn: () => void, delay: number) => {
@@ -66,7 +70,7 @@ export default function HeroDemo() {
 
     if (phase === "typing" && typedChars >= REQUEST_TEXT.length) {
       // Typing done -> show goal card
-      schedule(timeouts, () => setPhase("goal-appear"), 600);
+      schedule(timeouts, () => setPhase("goal-appear"), 350);
     } else if (phase === "goal-appear") {
       // Goal visible -> expand first check with task
       schedule(timeouts, () => setPhase("expand-task"), 1200);
@@ -100,21 +104,24 @@ export default function HeroDemo() {
       // Mark complete
       schedule(timeouts, () => setPhase("complete"), 400);
     } else if (phase === "complete") {
-      // Pause then fade out
-      schedule(timeouts, () => setPhase("fade-out"), 1500);
-    } else if (phase === "fade-out") {
-      // Reset and loop
+      // Pause then start the next cycle's request typing (goal card stays
+      // visible, dimmed, underneath — never unmounts to empty).
       schedule(timeouts, () => {
         setTypedChars(0);
         setPhase("typing");
-      }, 800);
+      }, 1500);
     }
 
     return () => timeouts.forEach(clearTimeout);
   }, [phase, typedChars, schedule]);
 
   // Derived state
-  const showGoal = phase !== "typing" && phase !== "fade-out";
+  // The goal card stays mounted through the typing phase (dimmed) instead
+  // of unmounting to an empty card — it only ever hides on true first mount
+  // before any cycle has completed, which never happens since we start
+  // mid-story at "complete".
+  const showGoal = true;
+  const isTyping = phase === "typing";
   const isExpanded =
     phase === "expand-task" ||
     phase === "rate-1" ||
@@ -133,11 +140,11 @@ export default function HeroDemo() {
   const showApproval = phase === "approval-show" || phase === "approved";
   const isApproved = phase === "approved";
   const checksChecked = [
-    ["check-1", "check-2", "check-3", "complete", "fade-out"].includes(phase),
-    ["check-2", "check-3", "complete", "fade-out"].includes(phase),
-    ["check-3", "complete", "fade-out"].includes(phase),
+    ["check-1", "check-2", "check-3", "complete", "typing"].includes(phase),
+    ["check-2", "check-3", "complete", "typing"].includes(phase),
+    ["check-3", "complete", "typing"].includes(phase),
   ];
-  const isComplete = phase === "complete" || phase === "fade-out";
+  const isComplete = phase === "complete" || phase === "typing";
   const goalTitle = isComplete ? "Processed" : "Process inquiry";
 
 
@@ -158,22 +165,14 @@ export default function HeroDemo() {
       flexDirection="column"
       overflow="hidden"
     >
-      {/* Outer fade for reset */}
+      {/* Content wrapper — always fully populated, never fades to empty.
+          Layout stays top-aligned in every phase since the goal card is
+          always present (dimmed while retyping the next request). */}
       <MotionBox
-        animate={{ opacity: phase === "fade-out" ? 0 : 1 }}
-        transition={{ duration: 0.6 }}
         display="flex"
         flexDirection="column"
         flex={1}
         overflow="hidden"
-        // During the typing-only phase the card holds just the request
-        // field — on mobile that reads as a mostly-empty box pinned to the
-        // top, so center it in the available height instead. Desktop keeps
-        // the original top-aligned layout unchanged.
-        justifyContent={{
-          base: phase === "typing" ? "center" : "flex-start",
-          md: "flex-start",
-        }}
       >
         {/* ── Request field ── */}
         <Box mb={4}>
@@ -190,7 +189,7 @@ export default function HeroDemo() {
           >
             <Text fontSize="sm" color="ink.primary" lineHeight="1.5">
               {REQUEST_TEXT.slice(0, typedChars)}
-              {phase === "typing" && <TypingCursor />}
+              {isTyping && <TypingCursor />}
             </Text>
           </Box>
         </Box>
@@ -201,7 +200,7 @@ export default function HeroDemo() {
             <MotionBox
               key="goal-card"
               initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
+              animate={{ opacity: isTyping ? 0.35 : 1, y: 0 }}
               exit={{ opacity: 0, y: -8 }}
               transition={{ duration: 0.35 }}
               flex={1}
@@ -412,6 +411,7 @@ export default function HeroDemo() {
                                                   : "500"
                                               }
                                               textAlign="right"
+                                              fontVariantNumeric="tabular-nums"
                                             >
                                               {rate.price}
                                             </Text>

--- a/src/components/Landing/HowDemos.tsx
+++ b/src/components/Landing/HowDemos.tsx
@@ -30,7 +30,7 @@ function Pill({
         green: { bg: "rgba(16,185,129,0.15)", color: "#34D399", border: "1px solid rgba(16,185,129,0.4)" },
       }
     : {
-        filled: { bg: "#EBF2FF", color: "#3B82F6", border: "1px solid #D4E4FF" },
+        filled: { bg: "rgba(73,8,45,0.08)", color: "#49082D", border: "1px solid rgba(73,8,45,0.15)" },
         dashed: { bg: "transparent", color: "#9CA3AF", border: "1.5px dashed #D1D5DB" },
         green: { bg: "#ECFDF5", color: "#10B981", border: "1px solid #A7F3D0" },
       };
@@ -51,7 +51,7 @@ function Pill({
       fontWeight="600"
       lineHeight="1.4"
       whiteSpace="nowrap"
-      boxShadow={glow ? "0 0 0 2px rgba(59,130,246,0.25)" : "none"}
+      boxShadow={glow ? (dark ? "0 0 0 2px rgba(223,174,192,0.35)" : "0 0 0 2px rgba(73,8,45,0.25)") : "none"}
       transition="box-shadow 0.3s"
     >
       {children}
@@ -129,10 +129,15 @@ const CREATE_CHECKS = [
 ];
 
 export function CreateDemo() {
-  const [userChars, setUserChars] = useState(0);
-  const [sent, setSent] = useState(false);
-  const [checksVisible, setChecksVisible] = useState(0);
-  const [fading, setFading] = useState(false);
+  // Mid-story start: the first visible frame already has the message sent
+  // and the first two check cards in place (>50% of the fullest 3-card
+  // frame), so typing/build-out happens with content on screen the whole
+  // time — never an empty or mostly-empty card. Loop resets crossfade from
+  // the full frame back to this same mid-story frame instead of unmounting
+  // to blank.
+  const [userChars, setUserChars] = useState(CREATE_USER_MSG.length);
+  const [sent, setSent] = useState(true);
+  const [checksVisible, setChecksVisible] = useState(CREATE_CHECKS.length);
   const [cycle, setCycle] = useState(0);
   const timeoutsRef = useRef<NodeJS.Timeout[]>([]);
 
@@ -140,28 +145,18 @@ export function CreateDemo() {
     const ts: NodeJS.Timeout[] = [];
     timeoutsRef.current = ts;
 
-    setUserChars(0);
-    setSent(false);
-    setChecksVisible(0);
-    setFading(false);
+    // Loop seam: no region fade — checks 2 and 3 exit with their own
+    // animations while the bubble, input bar and check 1 stay put, so the
+    // card never drops below bubble + one check. Each cycle then replays
+    // the build-out: check 2 lands, check 3 lands, hold on the full frame.
+    setUserChars(CREATE_USER_MSG.length);
+    setSent(true);
+    setChecksVisible(1);
 
-    const userLen = CREATE_USER_MSG.length;
-    const charMs = 30;
-    for (let i = 1; i <= userLen; i++) {
-      ts.push(setTimeout(() => setUserChars(i), i * charMs));
-    }
-    const typeDone = userLen * charMs;
+    ts.push(setTimeout(() => setChecksVisible(2), 1800));
+    ts.push(setTimeout(() => setChecksVisible(CREATE_CHECKS.length), 3200));
 
-    ts.push(setTimeout(() => setSent(true), typeDone + 300));
-
-    const checksStart = typeDone + 1000;
-    for (let i = 1; i <= CREATE_CHECKS.length; i++) {
-      ts.push(setTimeout(() => setChecksVisible(i), checksStart + i * 1200));
-    }
-    const checksDone = checksStart + CREATE_CHECKS.length * 1200;
-
-    ts.push(setTimeout(() => setFading(true), checksDone + 2000));
-    ts.push(setTimeout(() => setCycle((c) => c + 1), checksDone + 2600));
+    ts.push(setTimeout(() => setCycle((c) => c + 1), 6800));
 
     return () => ts.forEach(clearTimeout);
   }, [cycle]);
@@ -170,14 +165,7 @@ export function CreateDemo() {
 
   return (
     <DemoContainer variant="light" flush>
-      <MotionBox
-        display="flex"
-        flexDirection="column"
-        h="100%"
-        initial={{ opacity: 1 }}
-        animate={{ opacity: fading ? 0 : 1 }}
-        transition={{ duration: 0.5 }}
-      >
+      <MotionBox display="flex" flexDirection="column" h="100%">
         {/* Main area */}
         <Box flex="1" overflow="hidden">
           {/* Sent message as bubble */}
@@ -190,7 +178,7 @@ export function CreateDemo() {
                 transition={{ duration: 0.3 }}
                 display="flex"
                 justifyContent="flex-end"
-                mb={3}
+                mb={{ base: 2, md: 3 }}
               >
                 <Box
                   bg="#F3F2EF"
@@ -249,6 +237,7 @@ export function CreateDemo() {
                   key={`check-${ci}`}
                   initial={{ opacity: 0, y: 12 }}
                   animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -8 }}
                   transition={{ duration: 0.35 }}
                   mb={2}
                 >
@@ -264,7 +253,7 @@ export function CreateDemo() {
                       align="center"
                       gap={2}
                       px={3}
-                      py={2}
+                      py={{ base: 1.5, md: 2 }}
                       borderBottom="1px solid"
                       borderColor="#F3F2EF"
                     >
@@ -275,7 +264,7 @@ export function CreateDemo() {
                         border="1.5px solid #D6D3D1"
                         flexShrink={0}
                       />
-                      <Text fontSize="sm" fontWeight="600" color="#1A1A1A">
+                      <Text fontSize="sm" fontWeight="600" color="#1A1A1A" fontFamily="heading">
                         {check.name}
                       </Text>
                       <Text fontSize="xs" color="#9CA3AF" ml="auto">
@@ -284,17 +273,17 @@ export function CreateDemo() {
                     </Flex>
 
                     {/* Rules */}
-                    <Box px={3} py={1.5}>
+                    <Box px={3} py={{ base: 1, md: 1.5 }}>
                       {check.rules.map((rule, ri) => (
                         <Flex
                           key={ri}
                           align="center"
                           gap={1.5}
-                          py={1.5}
+                          py={{ base: 1, md: 1.5 }}
                           flexWrap="wrap"
                         >
-                          <Box bg="#EBF2FF" px={2} py={0.5} borderRadius="full">
-                            <Text fontSize="xs" color="#3B82F6" fontWeight="600">
+                          <Box bg="rgba(73,8,45,0.08)" px={2} py={0.5} borderRadius="full">
+                            <Text fontSize="xs" color="#49082D" fontWeight="600">
                               {rule.field}
                             </Text>
                           </Box>
@@ -371,59 +360,104 @@ export function CreateDemo() {
 }
 
 // ═══════════════════════════════════════════
-// Card 2 — View Demo (Generated interface for Quotes Collected check)
-// Form fields build in, table appears, counter updates, progress bar
+// Card 2 — View Demo (Generated interfaces for each check, feed-style)
+// Four checks stack top to bottom, each generating its own UI; the card
+// auto-scrolls its content so the newest check stays in frame.
 // ═══════════════════════════════════════════
 
+// Two fields keeps the baseline form compact enough that the card reads
+// clearly before the feed starts scrolling.
 const VIEW_FORM_FIELDS = [
   { label: "Carrier name", type: "dropdown", placeholder: "Select carrier...", value: "MSC" },
   { label: "Rate (USD)", type: "number", placeholder: "", value: "$2,840" },
-  { label: "Transit days", type: "number", placeholder: "", value: "18" },
 ] as const;
 
+// Small header for checks 2-4, reused across the generated feed.
+function MiniCheckHeader({ name }: { name: string }) {
+  return (
+    <Flex align="center" gap={1.5} mb={{ base: 1, md: 1.5 }}>
+      <Box w="6px" h="6px" borderRadius="full" bg="#49082D" flexShrink={0} />
+      <Text fontSize="xs" fontWeight="700" color="#1A1A1A" fontFamily="heading">
+        {name}
+      </Text>
+    </Flex>
+  );
+}
+
 export function ViewDemo() {
-  // Phases: 0=idle, 1=header appears, 2=section label, 3=field1, 4=field2,
-  //         5=field3, 6=fields fill, 7=table appears, 8=counter updates, 9=fade
-  const [phase, setPhase] = useState(0);
+  // Phases: 0=idle, 1=header appears, 6=check 1 (form) filled and settled,
+  //         7=check 2 generates (table), 8=check 3 generates (stat cards),
+  //         9=check 4 generates (bar chart), then hold, then loop.
+  // Mid-story start: first frame already has the header and check 1's
+  // filled form in view (phase 6) — never an empty/near-empty card. Loop
+  // resets crossfade-dim back to phase 6 instead of unmounting, and the
+  // scroll position returns to top with it.
+  const [phase, setPhase] = useState(6);
   const [cycle, setCycle] = useState(0);
+  const [fading, setFading] = useState(false);
+  const [feedY, setFeedY] = useState(0);
   const timeoutsRef = useRef<NodeJS.Timeout[]>([]);
+  const feedViewportRef = useRef<HTMLDivElement>(null);
+  const feedInnerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const ts: NodeJS.Timeout[] = [];
     timeoutsRef.current = ts;
-    setPhase(0);
 
-    ts.push(setTimeout(() => setPhase(1), 400));   // check header
-    ts.push(setTimeout(() => setPhase(2), 1000));  // section label
-    ts.push(setTimeout(() => setPhase(3), 1500));  // field 1
-    ts.push(setTimeout(() => setPhase(4), 2000));  // field 2
-    ts.push(setTimeout(() => setPhase(5), 2500));  // field 3
-    ts.push(setTimeout(() => setPhase(6), 3400));  // fields fill with values
-    ts.push(setTimeout(() => setPhase(7), 4600));  // table appears
-    ts.push(setTimeout(() => setPhase(8), 5800));  // counter updates to 1/3
-    ts.push(setTimeout(() => setPhase(9), 7500));  // fade out
-    ts.push(setTimeout(() => setCycle((c) => c + 1), 8500));
+    // Loop seam: fade only the generated-checks region (2-4) — check 1 +
+    // its filled form is the permanent baseline and never dims. Each cycle
+    // replays Colex generating a different interface per check: a mini
+    // table, then stat cards, then a bar chart, each landing below the
+    // last and scrolling the feed up to keep the newest in frame.
+    setFading(true);
+    ts.push(
+      setTimeout(() => {
+        setPhase(6);
+        setFading(false);
+      }, 350)
+    );
+
+    ts.push(setTimeout(() => setPhase(7), 1400));  // check 2: table generates
+    ts.push(setTimeout(() => setPhase(8), 2800));  // check 3: stat cards generate
+    ts.push(setTimeout(() => setPhase(9), 4200));  // check 4: bar chart generates
+    ts.push(setTimeout(() => setCycle((c) => c + 1), 8400));
 
     return () => ts.forEach(clearTimeout);
   }, [cycle]);
 
-  const visibleFields = phase >= 5 ? 3 : phase >= 4 ? 2 : phase >= 3 ? 1 : 0;
+  const visibleFields = VIEW_FORM_FIELDS.length;
   const fieldsFilled = phase >= 6;
-  const showTable = phase >= 7;
-  const counterUpdated = phase >= 8;
-  const fading = phase >= 9;
+  const showCheck2 = phase >= 7;
+  const showCheck3 = phase >= 8;
+  const showCheck4 = phase >= 9;
+  const checksVisible = showCheck4 ? 4 : showCheck3 ? 3 : showCheck2 ? 2 : 1;
+
+  // Scroll the feed only as far as the content actually overflows the
+  // clipped viewport, measured from the DOM — fixed per-phase offsets
+  // can't serve both card aspect ratios (they over-scrolled the taller
+  // phone card, clipping widgets mid-frame while leaving the bottom
+  // empty). Measured shortly after each widget mounts so its height is
+  // known; on phones where everything fits, the feed never moves.
+  useEffect(() => {
+    if (fading) {
+      setFeedY(0);
+      return;
+    }
+    const t = setTimeout(() => {
+      const vp = feedViewportRef.current;
+      const inner = feedInnerRef.current;
+      if (!vp || !inner) return;
+      const overflow = inner.scrollHeight - vp.clientHeight;
+      setFeedY(overflow > 0 ? -overflow : 0);
+    }, 120);
+    return () => clearTimeout(t);
+  }, [checksVisible, fading]);
+  const y = feedY;
 
   return (
     <DemoContainer variant="light" flush>
-      <MotionBox
-        display="flex"
-        flexDirection="column"
-        h="100%"
-        initial={{ opacity: 1 }}
-        animate={{ opacity: fading ? 0 : 1 }}
-        transition={{ duration: 0.5 }}
-      >
-        {/* Check header */}
+      <MotionBox display="flex" flexDirection="column" h="100%">
+        {/* Check header — counter reflects how many checks are visible */}
         <AnimatePresence>
           {phase >= 1 && (
             <MotionBox
@@ -432,186 +466,261 @@ export function ViewDemo() {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3 }}
               mb={{ base: 2, md: 3 }}
+              flexShrink={0}
             >
               <Flex align="center" gap={2}>
-                <Box w="8px" h="8px" borderRadius="full" bg="#3B82F6" flexShrink={0} />
-                <Text fontSize="sm" fontWeight="700" color="#1A1A1A">
-                  Quotes Collected
+                <Box w="8px" h="8px" borderRadius="full" bg="#49082D" flexShrink={0} />
+                <Text fontSize="sm" fontWeight="700" color="#1A1A1A" fontFamily="heading">
+                  Generated interface
                 </Text>
-                <Text fontSize="xs" color="#9CA3AF" ml="auto">
-                  {counterUpdated ? "1/3 quotes" : "0/3 quotes"}
+                <Text fontSize="xs" color="#9CA3AF" ml="auto" fontVariantNumeric="tabular-nums">
+                  {checksVisible} {checksVisible === 1 ? "view" : "views"}
                 </Text>
               </Flex>
             </MotionBox>
           )}
         </AnimatePresence>
 
-        {/* Section label */}
-        <AnimatePresence>
-          {phase >= 2 && (
-            <MotionBox
-              key="section-label"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ duration: 0.2 }}
-              mb={{ base: 1, md: 2 }}
-            >
-              <Text
-                fontSize="xs"
-                fontWeight="700"
-                color="#71717A"
-                textTransform="uppercase"
-                letterSpacing="0.04em"
-                display={{ base: "none", md: "block" }}
-              >
-                Carrier Quote Form
-              </Text>
-            </MotionBox>
-          )}
-        </AnimatePresence>
-
-        {/* Form fields — appear one by one */}
-        <AnimatePresence>
-          {Array.from({ length: visibleFields }).map((_, fi) => {
-            const field = VIEW_FORM_FIELDS[fi];
-            const filled = fieldsFilled;
-            return (
-              <MotionBox
-                key={`field-${fi}`}
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.25 }}
-                mb={{ base: 1, md: 2 }}
-              >
-                {/* Field label */}
-                <Text
-                  fontSize="xs"
-                  fontWeight="600"
-                  color="#71717A"
-                  textTransform="uppercase"
-                  letterSpacing="0.04em"
-                  mb={{ base: 0.5, md: 1 }}
-                >
-                  {field.label}
-                </Text>
-                {/* Field input */}
-                <Box
-                  bg="white"
-                  border="1px solid"
-                  borderColor="#E7E5E4"
-                  borderRadius="8px"
-                  px={3}
-                  py={{ base: 1, md: 1.5 }}
-                >
-                  <Flex align="center" justify="space-between">
-                    <Text
-                      fontSize="sm"
-                      color={filled ? "#1A1A1A" : "#9CA3AF"}
-                      fontWeight={filled ? "500" : "400"}
+        {/* Scrolling feed — clipped viewport, inner stack translates up as
+            later checks generate so the newest one stays in frame. */}
+        <Box
+          ref={feedViewportRef}
+          flex="1"
+          overflow="hidden"
+          position="relative"
+          // Fade the top edge so content scrolled out of the feed dissolves
+          // instead of hard-cutting mid-letter under the card title.
+          css={{
+            maskImage: "linear-gradient(to bottom, transparent 0%, black 7%, black 100%)",
+            WebkitMaskImage: "linear-gradient(to bottom, transparent 0%, black 7%, black 100%)",
+          }}
+        >
+          <MotionBox
+            ref={feedInnerRef}
+            animate={{ y }}
+            transition={{ duration: 0.45, ease: "easeInOut" }}
+          >
+            {/* Check 1 — starting frame, never dims */}
+            <Box mb={{ base: 2, md: 3 }}>
+              <MiniCheckHeader name="Quotes Collected" />
+              <AnimatePresence>
+                {Array.from({ length: visibleFields }).map((_, fi) => {
+                  const field = VIEW_FORM_FIELDS[fi];
+                  const filled = fieldsFilled;
+                  return (
+                    <MotionBox
+                      key={`field-${fi}`}
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.25 }}
+                      mb={{ base: 1, md: 2 }}
                     >
-                      {filled ? field.value : (field.placeholder || " ")}
-                    </Text>
-                    {field.type === "dropdown" && (
-                      <Text fontSize="xs" color="#9CA3AF" lineHeight="1">&#x25BE;</Text>
-                    )}
-                  </Flex>
-                </Box>
-              </MotionBox>
-            );
-          })}
-        </AnimatePresence>
+                      {/* Field label */}
+                      <Text
+                        fontSize="xs"
+                        fontWeight="600"
+                        color="#71717A"
+                        textTransform="uppercase"
+                        letterSpacing="0.04em"
+                        mb={{ base: 0.5, md: 1 }}
+                      >
+                        {field.label}
+                      </Text>
+                      {/* Field input */}
+                      <Box
+                        bg="white"
+                        border="1px solid"
+                        borderColor="#E7E5E4"
+                        borderRadius="8px"
+                        px={3}
+                        py={{ base: 1, md: 1.5 }}
+                      >
+                        <Flex align="center" justify="space-between">
+                          <Text
+                            fontSize="sm"
+                            color={filled ? "#1A1A1A" : "#9CA3AF"}
+                            fontWeight={filled ? "500" : "400"}
+                          >
+                            {filled ? field.value : (field.placeholder || " ")}
+                          </Text>
+                          {field.type === "dropdown" && (
+                            <Text fontSize="xs" color="#9CA3AF" lineHeight="1">&#x25BE;</Text>
+                          )}
+                        </Flex>
+                      </Box>
+                    </MotionBox>
+                  );
+                })}
+              </AnimatePresence>
+            </Box>
 
-        {/* Data table — quotes already collected */}
-        <AnimatePresence>
-          {showTable && (
-            <MotionBox
-              key="quote-table"
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.3 }}
-              mb={{ base: 1, md: 2 }}
-            >
-              <Box
-                bg="white"
-                border="1px solid"
-                borderColor="#E7E5E4"
-                borderRadius="8px"
-                overflow="hidden"
-              >
-                {/* Table header */}
-                <Flex
-                  bg="#F5F5F4"
-                  px={3}
-                  py={{ base: 1, md: 1.5 }}
-                  borderBottom="1px solid"
-                  borderColor="#E7E5E4"
-                >
-                  <Text flex={1} fontSize="xs" fontWeight="700" color="#71717A">
-                    Carrier
-                  </Text>
-                  <Text w="60px" fontSize="xs" fontWeight="700" color="#71717A" textAlign="right">
-                    Rate
-                  </Text>
-                  <Text w="50px" fontSize="xs" fontWeight="700" color="#71717A" textAlign="right">
-                    Transit
-                  </Text>
-                </Flex>
-                {/* Single row — just submitted */}
-                <MotionBox
-                  initial={{ opacity: 0, x: -6 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ duration: 0.2, delay: 0.1 }}
-                >
-                  <Flex px={3} py={{ base: 1, md: 1.5 }}>
-                    <Text flex={1} fontSize="sm" fontWeight="500" color="#1A1A1A">
-                      MSC
-                    </Text>
-                    <Text w="60px" fontSize="sm" color="#1A1A1A" textAlign="right">
-                      $2,840
-                    </Text>
-                    <Text w="50px" fontSize="sm" color="#71717A" textAlign="right">
-                      18d
-                    </Text>
-                  </Flex>
-                </MotionBox>
-              </Box>
-            </MotionBox>
-          )}
-        </AnimatePresence>
-
-        {/* Progress bar — 1/3 */}
-        <AnimatePresence>
-          {counterUpdated && (
-            <MotionBox
-              key="progress"
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.25 }}
-            >
-              <Flex align="center" gap={2}>
-                <Box
-                  flex={1}
-                  h="4px"
-                  bg="#E7E5E4"
-                  borderRadius="full"
-                  overflow="hidden"
-                >
+            {/* Checks 2-4 region — the only part that fades at the loop
+                seam; check 1 above never dims. */}
+            <MotionBox animate={{ opacity: fading ? 0 : 1 }} transition={{ duration: 0.35 }}>
+              {/* Generating caption — pulses while widgets build below */}
+              <AnimatePresence>
+                {phase < 9 && (
                   <MotionBox
-                    h="100%"
-                    bg="#3B82F6"
-                    borderRadius="full"
-                    initial={{ width: "0%" }}
-                    animate={{ width: "33.3%" }}
-                    transition={{ duration: 0.5 }}
-                  />
-                </Box>
-                <Text fontSize="xs" color="#9CA3AF" fontWeight="500" flexShrink={0}>
-                  1/3
-                </Text>
-              </Flex>
+                    key="gen-label"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.2 }}
+                    mb={{ base: 1, md: 1.5 }}
+                  >
+                    <Flex align="center" gap={1.5}>
+                      <Box
+                        w="6px"
+                        h="6px"
+                        borderRadius="full"
+                        bg="#49082D"
+                        css={{
+                          animation: "pulse-brand 1.2s infinite",
+                          "@keyframes pulse-brand": {
+                            "0%, 100%": { opacity: 1 },
+                            "50%": { opacity: 0.3 },
+                          },
+                        }}
+                      />
+                      <Text fontSize="xs" fontWeight="600" color="#49082D">
+                        Generating views from rules...
+                      </Text>
+                    </Flex>
+                  </MotionBox>
+                )}
+              </AnimatePresence>
+
+              {/* Check 2 — "Best Rate Flagged" → mini table */}
+              <AnimatePresence>
+                {showCheck2 && (
+                  <MotionBox
+                    key="check-2"
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3 }}
+                    mb={{ base: 2, md: 3 }}
+                  >
+                    <MiniCheckHeader name="Best Rate Flagged" />
+                    <Box
+                      bg="white"
+                      border="1px solid"
+                      borderColor="#E7E5E4"
+                      borderRadius="8px"
+                      overflow="hidden"
+                    >
+                      {/* Table header */}
+                      <Flex
+                        bg="#F5F5F4"
+                        px={3}
+                        py={{ base: 1, md: 1.5 }}
+                        borderBottom="1px solid"
+                        borderColor="#E7E5E4"
+                      >
+                        <Text flex={1} fontSize="xs" fontWeight="700" color="#71717A">
+                          Carrier
+                        </Text>
+                        <Text w="60px" fontSize="xs" fontWeight="700" color="#71717A" textAlign="right">
+                          Rate
+                        </Text>
+                        <Text w="50px" fontSize="xs" fontWeight="700" color="#71717A" textAlign="right">
+                          Transit
+                        </Text>
+                      </Flex>
+                      {/* Row lands */}
+                      <MotionBox
+                        initial={{ opacity: 0, x: -6 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        transition={{ duration: 0.2, delay: 0.1 }}
+                      >
+                        <Flex px={3} py={{ base: 1, md: 1.5 }}>
+                          <Text flex={1} fontSize="sm" fontWeight="500" color="#1A1A1A">
+                            MSC
+                          </Text>
+                          <Text w="60px" fontSize="sm" color="#1A1A1A" textAlign="right" fontVariantNumeric="tabular-nums">
+                            $2,840
+                          </Text>
+                          <Text w="50px" fontSize="sm" color="#71717A" textAlign="right" fontVariantNumeric="tabular-nums">
+                            18d
+                          </Text>
+                        </Flex>
+                      </MotionBox>
+                    </Box>
+                  </MotionBox>
+                )}
+              </AnimatePresence>
+
+              {/* Check 3 — "RFQ Sent" → stat cards */}
+              <AnimatePresence>
+                {showCheck3 && (
+                  <MotionBox
+                    key="check-3"
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3 }}
+                    mb={{ base: 2, md: 3 }}
+                  >
+                    <MiniCheckHeader name="RFQ Sent" />
+                    <Flex gap={2}>
+                      <Box flex={1} bg="white" border="1px solid" borderColor="#E7E5E4" borderRadius="8px" px={2.5} py={{ base: 1, md: 1.5 }}>
+                        <Text fontSize="9px" fontWeight="700" color="#71717A" textTransform="uppercase" letterSpacing="0.04em">
+                          Lowest rate
+                        </Text>
+                        <Text fontSize="sm" fontWeight="700" color="#49082D" fontVariantNumeric="tabular-nums">
+                          $2,840 <Text as="span" fontWeight="500" color="#71717A" fontSize="xs">MSC</Text>
+                        </Text>
+                      </Box>
+                      <Box flex={1} bg="white" border="1px solid" borderColor="#E7E5E4" borderRadius="8px" px={2.5} py={{ base: 1, md: 1.5 }}>
+                        <Text fontSize="9px" fontWeight="700" color="#71717A" textTransform="uppercase" letterSpacing="0.04em">
+                          RFQ
+                        </Text>
+                        <Text fontSize="sm" fontWeight="700" color="#1A1A1A">
+                          Sent
+                        </Text>
+                      </Box>
+                    </Flex>
+                  </MotionBox>
+                )}
+              </AnimatePresence>
+
+              {/* Check 4 — "Rate Comparison" → bar chart, bars grow in */}
+              <AnimatePresence>
+                {showCheck4 && (
+                  <MotionBox
+                    key="check-4"
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3 }}
+                  >
+                    <MiniCheckHeader name="Rate Comparison" />
+                    <Box bg="white" border="1px solid" borderColor="#E7E5E4" borderRadius="8px" px={3} py={{ base: 1.5, md: 2 }}>
+                      {[
+                        { label: "MSC", pct: 62, best: true },
+                        { label: "Hapag", pct: 71, best: false },
+                        { label: "ONE", pct: 100, best: false },
+                      ].map((bar, bi) => (
+                        <Flex key={bar.label} align="center" gap={2} py={0.5}>
+                          <Text w="44px" fontSize="9px" fontWeight="600" color="#71717A" flexShrink={0}>
+                            {bar.label}
+                          </Text>
+                          <Box flex={1} h="8px" bg="#F3F2EF" borderRadius="full" overflow="hidden">
+                            <MotionBox
+                              h="100%"
+                              bg={bar.best ? "#49082D" : "#D6D3D1"}
+                              borderRadius="full"
+                              initial={{ width: "0%" }}
+                              animate={{ width: `${bar.pct}%` }}
+                              transition={{ duration: 0.5, delay: 0.15 + bi * 0.12 }}
+                            />
+                          </Box>
+                        </Flex>
+                      ))}
+                    </Box>
+                  </MotionBox>
+                )}
+              </AnimatePresence>
             </MotionBox>
-          )}
-        </AnimatePresence>
+          </MotionBox>
+        </Box>
       </MotionBox>
     </DemoContainer>
   );
@@ -619,14 +728,22 @@ export function ViewDemo() {
 
 // ═══════════════════════════════════════════
 // Card 3 — Run Demo
-// Generative UI: check runs, table fills, best highlighted, approval
+// Generative UI: check runs, CTA-first, hand-typed 4th row, approval
 // ═══════════════════════════════════════════
 
+// The static comparison set — row 4 is NOT in here; it exists only as the
+// hand-typed row driven by the ROW4_* constants below.
 const RUN_RATE_ROWS = [
   { carrier: "MSC", rate: "$2,840", transit: "18d" },
   { carrier: "Hapag-Lloyd", rate: "$2,920", editedRate: "$2,850", transit: "16d" },
   { carrier: "ONE", rate: "$3,100", transit: "20d" },
 ];
+
+// The 4th row is hand-typed cell by cell once the CTA is tapped.
+const ROW4_CARRIER = "CMA CGM";
+const ROW4_RATE = "$2,980";
+const ROW4_TRANSIT = "21d";
+const TYPE_MS_PER_CHAR = 50;
 
 export function RunDemo() {
   // Phases:
@@ -635,43 +752,96 @@ export function RunDemo() {
   //  2 = table header + row 1 (MSC)
   //  3 = row 2 (Hapag-Lloyd)
   //  4 = row 3 (ONE)
-  //  5 = best rate highlighted (MSC gets brand tint + BEST pill)
+  //  5 = best rate highlighted (MSC gets brand tint + BEST pill), CTA
+  //      visible below the table from this point on — baseline frame
   //  6 = user edits Hapag-Lloyd rate (blue glow, value morphs)
   //  7 = "Edited" indicator on Hapag-Lloyd row
-  //  8 = approval bar slides in ("Review needed" amber)
-  //  9 = approval transitions to "Approved" green
-  // 10 = check ticks green, status DONE
-  // 11 = fade out, then loop
-  const [phase, setPhase] = useState(0);
+  //  8 = CTA pressed (scale dip)
+  //  9 = empty 4th row appears (input-look cells), CTA fades to disabled
+  // 10 = typing carrier "CMA CGM" cell by cell
+  // 11 = typing rate "$2,980" cell by cell
+  // 12 = typing transit "21d" cell by cell
+  // 13 = row complete: counter 4/4, check ticks green + DONE, Approved bar
+  // 14 = hold, then loop
+  // Mid-story start: first frame already has the check header, the full
+  // 3-row rate table, the best-rate highlight, and the CTA (phase 5) —
+  // never an empty/near-empty card. Loop resets crossfade-dim back to
+  // phase 5.
+  const [phase, setPhase] = useState(5);
   const [cycle, setCycle] = useState(0);
+  // Characters typed so far in each cell of row 4 — drives the
+  // hand-typed-row illusion independently of the coarser phase timeline.
+  const [typedCarrier, setTypedCarrier] = useState(0);
+  const [typedRate, setTypedRate] = useState(0);
+  const [typedTransit, setTypedTransit] = useState(0);
 
   useEffect(() => {
     const ts: NodeJS.Timeout[] = [];
-    setPhase(0);
 
-    ts.push(setTimeout(() => setPhase(1), 400));     // check header
-    ts.push(setTimeout(() => setPhase(2), 1200));    // table + row 1
-    ts.push(setTimeout(() => setPhase(3), 1900));    // row 2
-    ts.push(setTimeout(() => setPhase(4), 2600));    // row 3
-    ts.push(setTimeout(() => setPhase(5), 3600));    // best highlighted
-    ts.push(setTimeout(() => setPhase(6), 5000));    // edit glow + value change
-    ts.push(setTimeout(() => setPhase(7), 6200));    // "Edited" badge
-    ts.push(setTimeout(() => setPhase(8), 7200));    // approval bar (review needed)
-    ts.push(setTimeout(() => setPhase(9), 8400));    // approved
-    ts.push(setTimeout(() => setPhase(10), 9200));   // check done
-    ts.push(setTimeout(() => setPhase(11), 10200));  // fade out
-    ts.push(setTimeout(() => setCycle((c) => c + 1), 11000));
+    // Loop seam: no fade at all. Resetting to phase 5 unwinds the story in
+    // place — row 4 exits, the CTA resets to its untapped state, the
+    // edited value crossfades back, the check unticks to RUNNING —
+    // reading as a fresh run starting over the same table. The card never
+    // dims and never empties.
+    //
+    // Story: the check needs 4 quotes but the run found 3; a human edits a
+    // rate, then taps "Add quote" — an empty 4th row appears and fills in
+    // as if hand-typed, the check satisfies and approves.
+    setPhase(5);
+    setTypedCarrier(0);
+    setTypedRate(0);
+    setTypedTransit(0);
+
+    ts.push(setTimeout(() => setPhase(6), 2000));    // edit glow + value change
+    ts.push(setTimeout(() => setPhase(7), 3200));    // "Edited" badge
+    ts.push(setTimeout(() => setPhase(8), 4600));    // CTA pressed
+    ts.push(setTimeout(() => setPhase(9), 4900));    // empty 4th row appears
+
+    // Typing schedule: carrier starts shortly after the empty row lands,
+    // then rate, then transit — each a burst of per-char timeouts.
+    const carrierStart = 5300;
+    ts.push(setTimeout(() => setPhase(10), carrierStart));
+    for (let i = 1; i <= ROW4_CARRIER.length; i++) {
+      ts.push(
+        setTimeout(() => setTypedCarrier(i), carrierStart + i * TYPE_MS_PER_CHAR)
+      );
+    }
+
+    const rateStart = carrierStart + ROW4_CARRIER.length * TYPE_MS_PER_CHAR + 300;
+    ts.push(setTimeout(() => setPhase(11), rateStart));
+    for (let i = 1; i <= ROW4_RATE.length; i++) {
+      ts.push(setTimeout(() => setTypedRate(i), rateStart + i * TYPE_MS_PER_CHAR));
+    }
+
+    const transitStart = rateStart + ROW4_RATE.length * TYPE_MS_PER_CHAR + 300;
+    ts.push(setTimeout(() => setPhase(12), transitStart));
+    for (let i = 1; i <= ROW4_TRANSIT.length; i++) {
+      ts.push(
+        setTimeout(() => setTypedTransit(i), transitStart + i * TYPE_MS_PER_CHAR)
+      );
+    }
+
+    const rowDoneAt = transitStart + ROW4_TRANSIT.length * TYPE_MS_PER_CHAR + 400;
+    ts.push(setTimeout(() => setPhase(13), rowDoneAt));       // check done + approved
+    ts.push(setTimeout(() => setCycle((c) => c + 1), rowDoneAt + 3400));
 
     return () => ts.forEach(clearTimeout);
   }, [cycle]);
 
-  const visibleRows = phase >= 4 ? 3 : phase >= 3 ? 2 : phase >= 2 ? 1 : 0;
+  const visibleRows = RUN_RATE_ROWS.length;
   const bestHighlighted = phase >= 5;
   const editGlow = phase === 6;
   const rateEdited = phase >= 6;
-  const showEdited = phase >= 7 && phase < 11;
-  const checkDone = phase >= 10;
-  const fading = phase >= 11;
+  const showEdited = phase >= 7;
+  const ctaPressed = phase === 8;
+  const ctaSettled = phase >= 9;
+  const typingCarrier = phase === 10;
+  const typingRate = phase === 11;
+  const typingTransit = phase === 12;
+  const row4Complete = phase >= 13;
+  const checkDone = phase >= 13;
+  // Counter only ticks to 4 once the hand-typed row is complete.
+  const rowCount = row4Complete ? 4 : 3;
 
   return (
     <DemoContainer variant="light" flush>
@@ -679,9 +849,13 @@ export function RunDemo() {
         display="flex"
         flexDirection="column"
         h="100%"
-        initial={{ opacity: 1 }}
-        animate={{ opacity: fading ? 0 : 1 }}
-        transition={{ duration: 0.5 }}
+        // Mobile's taller 4:5 card aspect ratio leaves a big dead gap below
+        // the table before the approval bar (which is pinned to the bottom
+        // via a flex spacer below) — center the whole stack instead so the
+        // card never reads as mostly empty. Desktop keeps the original
+        // top-anchored, bottom-pinned layout (unchanged, matches 4:3 card).
+        justifyContent={{ base: "center", md: "flex-start" }}
+        gap={{ base: 4, md: 0 }}
       >
         {/* Check header with rule */}
         <AnimatePresence>
@@ -717,14 +891,14 @@ export function RunDemo() {
                       </MotionBox>
                     )}
                   </Box>
-                  <Text fontSize="sm" fontWeight="700" color="#1A1A1A">
+                  <Text fontSize="sm" fontWeight="700" color="#1A1A1A" fontFamily="heading">
                     Quotes Collected
                   </Text>
                 </Flex>
                 <StatusBadge status={checkDone ? "done" : "running"} />
               </Flex>
-              <Text fontSize="xs" color="#4A443E" ml={6}>
-                &#x2265; 3 carrier quotes
+              <Text fontSize="xs" color="#4A443E" ml={6} fontVariantNumeric="tabular-nums">
+                &#x2265; 4 carrier quotes &middot; {rowCount}/4
               </Text>
             </MotionBox>
           )}
@@ -766,7 +940,8 @@ export function RunDemo() {
                   </Text>
                 </Flex>
 
-                {/* Data rows */}
+                {/* Rows 1-3 — the static comparison set */}
+                <AnimatePresence initial={false}>
                 {RUN_RATE_ROWS.slice(0, visibleRows).map((row, i) => {
                   const isBest = i === 0 && bestHighlighted;
                   const isEditRow = i === 1;
@@ -780,12 +955,13 @@ export function RunDemo() {
                       key={row.carrier}
                       initial={{ opacity: 0, x: -6 }}
                       animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -6 }}
                       transition={{ duration: 0.2 }}
                     >
                       <Flex
                         px={3}
                         py={{ base: 1, md: 1.5 }}
-                        borderBottom={i < RUN_RATE_ROWS.length - 1 ? "1px solid" : "none"}
+                        borderBottom="1px solid"
                         borderColor="#F3F4F6"
                         bg={isBest ? "rgba(73,8,45,0.04)" : "transparent"}
                         transition="background 0.3s"
@@ -818,17 +994,21 @@ export function RunDemo() {
                               </Box>
                             </MotionBox>
                           )}
-                          {isEditRow && showEdited && (
-                            <MotionBox
-                              initial={{ opacity: 0, scale: 0.8 }}
-                              animate={{ opacity: 1, scale: 1 }}
-                              transition={{ duration: 0.2 }}
-                            >
-                              <Text fontSize="9px" fontWeight="600" color="#3B82F6">
-                                Edited
-                              </Text>
-                            </MotionBox>
-                          )}
+                          <AnimatePresence>
+                            {isEditRow && showEdited && (
+                              <MotionBox
+                                key="edited-badge"
+                                initial={{ opacity: 0, scale: 0.8 }}
+                                animate={{ opacity: 1, scale: 1 }}
+                                exit={{ opacity: 0, scale: 0.8 }}
+                                transition={{ duration: 0.2 }}
+                              >
+                                <Text fontSize="9px" fontWeight="600" color="#49082D">
+                                  Edited
+                                </Text>
+                              </MotionBox>
+                            )}
+                          </AnimatePresence>
                         </Flex>
                         <Box
                           w="60px"
@@ -839,7 +1019,7 @@ export function RunDemo() {
                           transition="box-shadow 0.3s"
                           boxShadow={
                             isEditRow && editGlow
-                              ? "0 0 0 2px rgba(59,130,246,0.35)"
+                              ? "0 0 0 2px rgba(73,8,45,0.3)"
                               : "none"
                           }
                         >
@@ -855,34 +1035,138 @@ export function RunDemo() {
                                 fontSize="sm"
                                 color={isBest ? "#49082D" : "#1A1A1A"}
                                 fontWeight={isBest ? "700" : "400"}
+                                fontVariantNumeric="tabular-nums"
                               >
                                 {displayRate}
                               </Text>
                             </MotionBox>
                           </AnimatePresence>
                         </Box>
-                        <Text w="50px" fontSize="sm" color="#71717A" textAlign="right">
+                        <Text w="50px" fontSize="sm" color="#71717A" textAlign="right" fontVariantNumeric="tabular-nums">
                           {row.transit}
                         </Text>
                       </Flex>
                     </MotionBox>
                   );
                 })}
+                </AnimatePresence>
+
+                {/* Row 4 — empty input-look cells appear on CTA tap, then
+                    fill in cell by cell as if hand-typed. Exits at the
+                    loop seam with the existing exit animation. */}
+                <AnimatePresence initial={false}>
+                  {phase >= 9 && (
+                    <MotionBox
+                      key="row-4"
+                      initial={{ opacity: 0, x: -6 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -6 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <Flex px={3} py={{ base: 1, md: 1.5 }} align="center">
+                        {/* Carrier cell */}
+                        <Flex flex={1} align="center">
+                          {typedCarrier === 0 && !row4Complete ? (
+                            <Box
+                              w="70px"
+                              h="14px"
+                              borderBottom="1.5px solid #D6D3D1"
+                            />
+                          ) : (
+                            <Text fontSize="sm" fontWeight="500" color="#1A1A1A">
+                              {ROW4_CARRIER.slice(0, typedCarrier || ROW4_CARRIER.length)}
+                              {typingCarrier && <TypingCursor />}
+                            </Text>
+                          )}
+                        </Flex>
+                        {/* Rate cell */}
+                        <Box w="60px" textAlign="right">
+                          {typedRate === 0 && !row4Complete ? (
+                            <Box
+                              w="44px"
+                              h="14px"
+                              ml="auto"
+                              borderBottom="1.5px solid #D6D3D1"
+                            />
+                          ) : (
+                            <Text fontSize="sm" color="#1A1A1A" fontVariantNumeric="tabular-nums">
+                              {ROW4_RATE.slice(0, typedRate || ROW4_RATE.length)}
+                              {typingRate && <TypingCursor />}
+                            </Text>
+                          )}
+                        </Box>
+                        {/* Transit cell */}
+                        <Box w="50px" textAlign="right">
+                          {typedTransit === 0 && !row4Complete ? (
+                            <Box
+                              w="30px"
+                              h="14px"
+                              ml="auto"
+                              borderBottom="1.5px solid #D6D3D1"
+                            />
+                          ) : (
+                            <Text fontSize="sm" color="#71717A" fontVariantNumeric="tabular-nums">
+                              {ROW4_TRANSIT.slice(0, typedTransit || ROW4_TRANSIT.length)}
+                              {typingTransit && <TypingCursor />}
+                            </Text>
+                          )}
+                        </Box>
+                      </Flex>
+                    </MotionBox>
+                  )}
+                </AnimatePresence>
               </Box>
             </MotionBox>
           )}
         </AnimatePresence>
 
-        {/* Spacer to push approval bar toward bottom */}
-        <Box flex="1" />
-
-        {/* Approval bar */}
+        {/* "Add quote" CTA — visible from the baseline frame, presses down
+            when "tapped", then stays visible but disabled-looking while
+            the 4th row fills in by hand */}
         <AnimatePresence>
-          {phase >= 8 && phase < 11 && (
+          {phase >= 5 && (
+            <MotionBox
+              key="add-quote-cta"
+              initial={{ opacity: 0, y: 6 }}
+              animate={{
+                opacity: ctaSettled ? 0.5 : 1,
+                y: 0,
+                scale: ctaPressed ? 0.96 : 1,
+              }}
+              exit={{ opacity: 0, y: 4 }}
+              transition={{ duration: 0.2 }}
+              mt={{ base: 0, md: 2 }}
+            >
+              <Flex
+                align="center"
+                justify="center"
+                w="100%"
+                bg={ctaPressed ? "#38061F" : "#49082D"}
+                color="white"
+                borderRadius="8px"
+                py={{ base: 1.5, md: 2 }}
+                transition="background 0.15s"
+                boxShadow={ctaPressed || ctaSettled ? "none" : "0 2px 8px rgba(73,8,45,0.25)"}
+              >
+                <Text fontSize="sm" fontWeight="600">+ Add quote</Text>
+              </Flex>
+            </MotionBox>
+          )}
+        </AnimatePresence>
+
+        {/* Spacer to push approval bar toward bottom — desktop only; mobile
+            uses justify="space-between" on the outer flex instead so the
+            gap between table and approval bar doesn't read as empty card. */}
+        <Box flex={{ base: "0", md: "1" }} />
+
+        {/* Approval bar — arrives once the 4th quote satisfies the check */}
+        <AnimatePresence>
+          {phase >= 13 && (
             <MotionBox
               key="approval"
               initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 6 }}
               transition={{ duration: 0.25 }}
             >
               <Flex
@@ -890,7 +1174,7 @@ export function RunDemo() {
                 justify="space-between"
                 bg="white"
                 border="1px solid"
-                borderColor={phase >= 9 ? "#10B981" : "#E7E5E4"}
+                borderColor="#10B981"
                 borderRadius="8px"
                 px={3}
                 py={{ base: 1, md: 1.5 }}
@@ -902,51 +1186,31 @@ export function RunDemo() {
                     w="18px"
                     h="18px"
                     borderRadius="full"
-                    bg={phase >= 9 ? "#10B981" : "#F59E0B"}
+                    bg="#10B981"
                     display="flex"
                     alignItems="center"
                     justifyContent="center"
                     transition="background 0.3s"
                   >
-                    {phase >= 9 ? (
-                      <MotionBox
-                        initial={{ scale: 0 }}
-                        animate={{ scale: 1 }}
-                        transition={{ type: "spring", stiffness: 500, damping: 25 }}
-                      >
-                        <Text fontSize="9px" color="white" lineHeight="1">&#x2713;</Text>
-                      </MotionBox>
-                    ) : (
-                      <Box w="6px" h="6px" borderRadius="full" bg="white" />
-                    )}
-                  </Box>
-                  <AnimatePresence mode="wait">
                     <MotionBox
-                      key={phase >= 9 ? "approved" : "review"}
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                      transition={{ duration: 0.2 }}
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      transition={{ type: "spring", stiffness: 500, damping: 25 }}
                     >
-                      <Text
-                        fontSize="sm"
-                        color={phase >= 9 ? "#10B981" : "#F59E0B"}
-                        fontWeight="600"
-                      >
-                        {phase >= 9 ? "Approved" : "Review needed"}
-                      </Text>
+                      <Text fontSize="9px" color="white" lineHeight="1">&#x2713;</Text>
                     </MotionBox>
-                  </AnimatePresence>
+                  </Box>
+                  <Text fontSize="sm" color="#10B981" fontWeight="600">
+                    Approved
+                  </Text>
                 </Flex>
-                {phase >= 9 && (
-                  <MotionBox
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <Text fontSize="xs" color="#9CA3AF">auto</Text>
-                  </MotionBox>
-                )}
+                <MotionBox
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <Text fontSize="xs" color="#9CA3AF">auto</Text>
+                </MotionBox>
               </Flex>
             </MotionBox>
           )}
@@ -984,22 +1248,22 @@ export function UpdateDemo() {
 
   return (
     <DemoContainer variant="maroon" flush>
-      {/* Base: center+distribute so sparse early phases don't leave a dead
-          gap under the rule box; md+: natural top-anchored stack (unchanged). */}
-      <Flex direction="column" flex="1" justifyContent={{ base: "center", md: "flex-start" }} gap={{ base: 4, md: 0 }}>
+      {/* Center+distribute at every width — top-anchoring left a dead gap
+          under the form box on desktop panel heights too. */}
+      <Flex direction="column" flex="1" justifyContent="center" gap={{ base: 4, md: 3 }}>
       {/* Rule section */}
       <Box>
       <SectionHeader dark>Rule updated</SectionHeader>
       <Box
         bg="rgba(255,255,255,0.06)"
         border="1.5px solid"
-        borderColor={phase >= 1 && phase <= 2 ? "#3B82F6" : phase >= 6 ? "#10B981" : "rgba(255,255,255,0.12)"}
+        borderColor={phase >= 1 && phase <= 2 ? "#DFAEC0" : phase >= 6 ? "#10B981" : "rgba(255,255,255,0.12)"}
         borderRadius="8px"
         px={3}
         py={{ base: 3, md: 2 }}
         mb={{ base: 0, md: 2 }}
         transition="border-color 0.3s"
-        boxShadow={phase >= 1 && phase <= 2 ? "0 0 0 2px rgba(59,130,246,0.2)" : "none"}
+        boxShadow={phase >= 1 && phase <= 2 ? "0 0 0 2px rgba(223,174,192,0.25)" : "none"}
       >
         <Flex align="center" gap={2} flexWrap="wrap">
           <Pill dark glow={phase === 1} variant={phase >= 6 ? "green" : "filled"}>
@@ -1007,7 +1271,7 @@ export function UpdateDemo() {
           </Pill>
           {phase >= 2 && (
             <MotionBox initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-              <Text fontSize="xs" color="#60A5FA" fontWeight="600">changed</Text>
+              <Text fontSize="xs" color="#DFAEC0" fontWeight="600">changed</Text>
             </MotionBox>
           )}
         </Flex>
@@ -1095,10 +1359,10 @@ export function UpdateDemo() {
                 animate={{ opacity: 1, height: "auto" }}
                 transition={{ duration: 0.3 }}
               >
-                <Flex align="center" gap={2} bg="rgba(59,130,246,0.15)" mx={-3} px={3} py={1.5} borderRadius="8px">
-                  <Box w="8px" h="8px" borderRadius="full" bg="#60A5FA" flexShrink={0} />
-                  <Text fontSize="sm" color="#60A5FA" fontWeight="600">3rd quote required</Text>
-                  <Badge bg="#3B82F6">NEW</Badge>
+                <Flex align="center" gap={2} bg="rgba(223,174,192,0.18)" mx={-3} px={3} py={1.5} borderRadius="8px">
+                  <Box w="8px" h="8px" borderRadius="full" bg="#DFAEC0" flexShrink={0} />
+                  <Text fontSize="sm" color="#DFAEC0" fontWeight="600">3rd quote required</Text>
+                  <Badge bg="#DFAEC0">NEW</Badge>
                 </Flex>
               </MotionBox>
             </Box>

--- a/src/components/Landing/VerticalDemo.tsx
+++ b/src/components/Landing/VerticalDemo.tsx
@@ -17,7 +17,7 @@ const C = {
   border: "rgba(255,255,255,0.1)",
   cardBg: "rgba(255,255,255,0.05)",
   green: "#10B981",
-  blue: "#3B82F6",
+  accent: "#C9909F", // dusty rose brand accent (replaces generic SaaS blue on dark grounds)
   amber: "#F59E0B",
   trackBg: "rgba(255,255,255,0.1)",
   fieldBg: "rgba(255,255,255,0.06)",
@@ -416,11 +416,11 @@ function ProgressBar({
   return (
     <Box mb={3}>
       <Flex align="center" justify="space-between" mb={2}>
-        <Text fontSize="sm" fontWeight="600" color={C.text}>
+        <Text fontSize="sm" fontWeight="600" color={C.text} fontVariantNumeric="tabular-nums">
           {completed}/{total}
         </Text>
         {needsYou > 0 && (
-          <Text fontSize="sm" color={C.blue} fontWeight="500">
+          <Text fontSize="sm" color={C.accent} fontWeight="500">
             {needsYou} needs you &rarr;
           </Text>
         )}
@@ -430,7 +430,7 @@ function ProgressBar({
       </Flex>
       <Box bg={C.trackBg} borderRadius="2px" h="5px" overflow="hidden">
         <Box
-          bg={allDone ? C.green : C.blue}
+          bg={allDone ? C.green : C.accent}
           h="100%"
           borderRadius="2px"
           w={`${pct}%`}
@@ -473,7 +473,7 @@ function GoalCard({
         mb={state === "active" && activeCheckViz ? 2 : 0}
       >
         <Box>
-          <Text fontSize="sm" fontWeight="600" color={C.text} mb={0.5}>
+          <Text fontSize="sm" fontFamily="heading" fontWeight="600" color={C.text} mb={0.5}>
             {goal.name}
           </Text>
           <Text fontSize="xs" color={checkStatusColor} fontWeight="500">
@@ -508,7 +508,7 @@ function GoalCard({
             w="6px"
             h="6px"
             borderRadius="full"
-            bg={C.blue}
+            bg={C.accent}
             flexShrink={0}
             css={{
               animation: "goal-pulse 1.5s infinite",
@@ -572,7 +572,7 @@ function FormViz({
                 {f.label}
               </Text>
               {f.required && (
-                <Text fontSize="xs" color={C.blue} fontWeight="600">
+                <Text fontSize="xs" color={C.accent} fontWeight="600">
                   *
                 </Text>
               )}
@@ -1050,6 +1050,12 @@ export default function VerticalDemo({
             <Box
               flex="1"
               overflow="hidden"
+              // Center the goal stack vertically — in end-of-cycle states
+              // (all goals collapsed to their compact "done" form) a
+              // top-anchored stack left a large dead gap above the footer.
+              display="flex"
+              flexDirection="column"
+              justifyContent="center"
               css={{
                 maskImage: "linear-gradient(to bottom, black 88%, transparent 100%)",
                 WebkitMaskImage: "linear-gradient(to bottom, black 88%, transparent 100%)",
@@ -1085,7 +1091,7 @@ export default function VerticalDemo({
               borderTop="1px solid"
               borderColor="rgba(255,255,255,0.08)"
             >
-              <Text fontSize="sm" color={C.muted} fontWeight="500">
+              <Text fontSize="sm" color={C.muted} fontWeight="500" fontVariantNumeric="tabular-nums">
                 {anim.completedGoals}/{totalGoals} goals
               </Text>
               {anim.allDone ? (
@@ -1106,7 +1112,7 @@ export default function VerticalDemo({
                     w="6px"
                     h="6px"
                     borderRadius="full"
-                    bg={C.blue}
+                    bg={C.accent}
                     css={{
                       animation: "vd-pulse 1.5s infinite",
                       "@keyframes vd-pulse": {

--- a/src/components/Landing/demo-primitives.tsx
+++ b/src/components/Landing/demo-primitives.tsx
@@ -93,7 +93,7 @@ export function StatusBadge({
   status: "running" | "review" | "done";
 }) {
   const config = {
-    running: { bg: "#3B82F6", label: "RUNNING" },
+    running: { bg: "#49082D", label: "RUNNING" },
     review: { bg: "#F59E0B", label: "REVIEW" },
     done: { bg: "#10B981", label: "DONE" },
   };


### PR DESCRIPTION
## What

Full rework of the demo-card animations (Hero, How ×3, Get ×4, Teams):

- **Never-empty choreography** — every demo opens mid-story and loops without blank frames; seams unwind in place (Run) or crossfade only the changing region (Create/View), never the whole card.
- **Brand palette in the mock-UIs** — oxblood accents on light grounds, brightened dusty rose (#DFAEC0) on the maroon Get cards, deep rose on near-black Teams cards; serif check names; tabular numerals; all generic SaaS blue removed.
- **Richer stories**
  - Hero: fast typing (10ms/char), goal card stays visible while retyping.
  - View: four checks each generate their own UI (form → table → stat cards → bar chart) in a scrolling feed; scroll distance is measured from actual overflow, with a top fade mask.
  - Run: "Add quote" CTA visible from frame one; the tap adds an empty row that's hand-typed cell by cell → 4/4 → DONE → Approved.
  - Rewind: the cascade now reverts **all** downstream steps (fixed impossible "later step done under a reopened one" state); counter follows 3/3 → 2/3 → 0/3.
- **Layout fixes** — dead space removed on both viewports (centered stacks in Run/View/Update/Rewind/Connect/Teams); Create no longer clips its third check on phones.

## Verification

- `npx tsc --noEmit` clean, `npm run lint` clean (one pre-existing GetDemos useEffect-deps warning), `npx vitest run` 65/65.
- Timed screenshot sweeps (iPhone 14 Pro + 1440×900) across animation cycles for every card; layout audit caught and fixed the double CMA CGM row, the over-scrolled View feed, and the Rewind state bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gCGsXe7FDzkTWGZ9HJMfg