### PR TITLE
Ledger scatter: cursor-reactive ledger grid across the site

### DIFF
--- a/src/components/Landing/BookDemoSection.tsx
+++ b/src/components/Landing/BookDemoSection.tsx
@@ -5,7 +5,7 @@ import { getEarlyAccess } from "@/lib/utils";
 
 export default function BookDemoSection() {
   return (
-    <Box as="section" id="book-demo" py={{ base: 14, md: 28 }}>
+    <Box as="section" id="book-demo" pt={{ base: 14, md: 28 }} pb={{ base: 6, md: 10 }}>
       <Container maxW="container.xl" px={{ base: 4, sm: 6, md: 8, lg: 12 }}>
         <Heading
           as="h2"

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -14,11 +14,7 @@ import Image from "next/image";
 import { getEarlyAccess } from "@/lib/utils";
 import dynamic from "next/dynamic";
 
-const WireframeGrid = dynamic(() => import("./WireframeGrid"), { ssr: false });
-const GridTuner = dynamic(
-  () => import("./WireframeGrid").then((m) => m.GridTuner),
-  { ssr: false }
-);
+const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
 
 const FOOTER_LINKS = [
   { label: "Blog", href: "/blog" },
@@ -30,14 +26,12 @@ const FOOTER_LINKS = [
 export default function Footer({ transparentBg = false }: { transparentBg?: boolean }) {
   return (
     <Box as="footer" bg={transparentBg ? "transparent" : "brand.primary"} pt={{ base: 12, lg: 20 }} position="relative">
-      {/* Dev-only tuner; renders nothing in production builds */}
-      <GridTuner />
-      {/* When the footer owns its background (e.g. blog pages), it also owns
-          the wireframe grid; on the landing page the parent wrapper provides
-          one continuous grid across CTA + footer instead. */}
+      {/* When the footer owns its background, it also owns the reactive
+          ledger — feathered into the maroon ground on all four sides, same
+          treatment we've always had here. */}
       {!transparentBg && (
         <>
-          <WireframeGrid preset="blog" lineColor="rgba(248,247,244,0.35)" />
+          <LedgerScatter preset="blog" />
           <Box
             position="absolute"
             inset={0}
@@ -52,7 +46,7 @@ export default function Footer({ transparentBg = false }: { transparentBg?: bool
               content: '""',
               position: "absolute",
               inset: 0,
-              background: "linear-gradient(to bottom, #49082D 0%, transparent 20%, transparent 80%, #49082D 100%)",
+              background: "linear-gradient(to bottom, #49082D 0%, transparent 55%, transparent 85%, #49082D 100%)",
             }}
           />
         </>

--- a/src/components/Landing/FooterBand.tsx
+++ b/src/components/Landing/FooterBand.tsx
@@ -3,39 +3,20 @@
 import { Box } from "@chakra-ui/react";
 import BookDemoSection from "./BookDemoSection";
 import Footer from "./Footer";
-import dynamic from "next/dynamic";
 
-const WireframeGrid = dynamic(() => import("./WireframeGrid"), { ssr: false });
-
-/** CTA + footer sharing one continuous wireframe grid on the maroon ground. */
+/**
+ * CTA + footer sharing the maroon ground. The CTA ("Bring us the process
+ * that keeps breaking.") sits on brand oxblood with no ledger; only the
+ * actual footer strip below carries the reactive ledger, which it owns
+ * fully (Footer renders it when transparentBg is false).
+ */
 export default function FooterBand() {
   return (
-    <Box position="relative" bg="brand.primary">
-      <WireframeGrid preset="footer" lineColor="rgba(248,247,244,0.35)" />
-      {/* Feather grid edges into the maroon bg on all 4 sides */}
-      <Box
-        position="absolute"
-        inset={0}
-        pointerEvents="none"
-        _before={{
-          content: '""',
-          position: "absolute",
-          inset: 0,
-          background:
-            "linear-gradient(to right, #49082D 0%, transparent 20%, transparent 80%, #49082D 100%)",
-        }}
-        _after={{
-          content: '""',
-          position: "absolute",
-          inset: 0,
-          background:
-            "linear-gradient(to bottom, #49082D 0%, transparent 20%, transparent 80%, #49082D 100%)",
-        }}
-      />
-      <Box position="relative" zIndex={1}>
+    <>
+      <Box bg="brand.primary">
         <BookDemoSection />
-        <Footer transparentBg />
       </Box>
-    </Box>
+      <Footer />
+    </>
   );
 }

--- a/src/components/Landing/GetSection.tsx
+++ b/src/components/Landing/GetSection.tsx
@@ -9,7 +9,7 @@ import { UpdateDemo } from "./HowDemos";
 import { ConnectDemo } from "./ConnectDemo";
 import dynamic from "next/dynamic";
 
-const WireframeGrid = dynamic(() => import("./WireframeGrid"), { ssr: false });
+const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
 
 const cards = [
   {
@@ -75,7 +75,7 @@ export default function GetSection() {
                 overflow="hidden"
               >
                 {/* Neat wireframe */}
-                <WireframeGrid preset="get" lineColor="rgba(248,247,244,0.12)" />
+                <LedgerScatter preset="get" />
 
                 {/* Maroon dim overlay on top of Neat */}
                 <Box

--- a/src/components/Landing/HeroSection.tsx
+++ b/src/components/Landing/HeroSection.tsx
@@ -7,7 +7,7 @@ import { getEarlyAccess } from "@/lib/utils";
 import HeroDemo from "./HeroDemo";
 import dynamic from "next/dynamic";
 
-const WireframeGrid = dynamic(() => import("./WireframeGrid"), { ssr: false });
+const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
 
 const MotionBox = motion.create(Box);
 
@@ -37,7 +37,7 @@ export default function HeroSection() {
         w={{ base: "0%", lg: "55%" }}
         display={{ base: "none", lg: "block" }}
       >
-        <WireframeGrid preset="hero" />
+        <LedgerScatter preset="hero" />
         {/* Left edge gradient to merge into page bg */}
         <Box
           position="absolute"

--- a/src/components/Landing/HowSection.tsx
+++ b/src/components/Landing/HowSection.tsx
@@ -5,7 +5,7 @@ import { getEarlyAccess } from "@/lib/utils";
 import { CreateDemo, ViewDemo, RunDemo } from "./HowDemos";
 import dynamic from "next/dynamic";
 
-const WireframeGrid = dynamic(() => import("./WireframeGrid"), { ssr: false });
+const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
 
 const steps = [
   {
@@ -123,7 +123,7 @@ export default function HowSection() {
                   borderRadius="20px"
                 >
                   {/* Neat animated gradient behind card */}
-                  <WireframeGrid preset="how" />
+                  <LedgerScatter preset="how" />
                   {/* Feather edges into page bg */}
                   <Box
                     position="absolute"

--- a/src/components/Landing/LedgerScatter.tsx
+++ b/src/components/Landing/LedgerScatter.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+/**
+ * LedgerScatter — cursor-reactive ledger background.
+ *
+ * Drop-in replacement for the WireframeGrid component: same call signature
+ * (`preset`, `lineColor`) is accepted but the visual is entirely different —
+ * a still ledger grid whose cells probabilistically ignite around the mouse
+ * with an eased trail, plus the ledger's numeral column + corner stamp.
+ *
+ * Config below is baked from the tuned values chosen in the artifact
+ * (see /docs internal or the scratchpad artifact for the source config).
+ * Only the palette-aware ink colours are picked per-preset; every other
+ * knob is one constant across the site so the reactive character is
+ * consistent from hero to footer.
+ */
+
+import { useEffect, useRef } from "react";
+
+export type LedgerScatterPreset =
+  | "hero"
+  | "how"
+  | "get"
+  | "verticals"
+  | "footer"
+  | "blog"
+  | "pain";
+
+interface LedgerScatterProps {
+  preset?: LedgerScatterPreset;
+  /** Accepted for API parity with the previous WireframeGrid; ignored — the
+   *  ledger picks palette-aware ink from `preset`. */
+  lineColor?: string;
+  /** Override the canvas's opaque background fill. Use this when the
+   *  container's background differs from the palette default (e.g. FooterBand
+   *  paints the whole section on a deep-shade maroon; without this override
+   *  the ledger canvas re-paints bright oxblood on top of it). */
+  groundColor?: string;
+}
+
+// ── Config (baked from the tuned scatter values) ────────────────────────────
+// dense = true and radius+= 1 bumps; band offset on, classic look off.
+const IGNITE_BASE_PER_S = 4.7 * 2.5;   // "denser scatter" multiplies ignite × 2.5
+const RADIUS_CELLS = 3 + 1;            // "denser scatter" adds +1 to radius
+const MAX_STRENGTH_MULT = 1;
+const UP_RATE = 15;
+const DOWN_RATE = 1.8;
+const TGT_DECAY = 1;
+const EASE_POS = 0.5;
+const BAND_OFFSET_FRAC = 0.65;         // fraction of H_SP to shift bands vertically
+
+const H_SP_CSS = 30;                    // horizontal ruling spacing (css px)
+const V_SP_CSS = 40;                    // vertical ruling spacing
+const LEGACY_PERIOD_CSS = 60;           // band period (1 row shaded + 1 empty)
+const LEGACY_FILL_CSS = 30;             // shaded portion within the period
+
+// Palette per preset. Grounds match the section backgrounds in the codebase.
+type Palette = "light" | "dark" | "oxblood";
+const PRESET_PALETTE: Record<LedgerScatterPreset, Palette> = {
+  hero: "light",       // paper right-half of hero → paper ground
+  how: "light",        // ledger sits INSIDE surface.raised cards (paper) → paper ground
+  get: "oxblood",      // ledger sits INSIDE brand.primary cards (oxblood) → oxblood ground
+  verticals: "dark",   // section bg is ink.primary → near-black ground
+  pain: "dark",        // section bg is ink.primary → near-black ground
+  footer: "oxblood",   // brand.primary footer → oxblood ground
+  blog: "oxblood",     // brand.primary blog footer → oxblood ground
+};
+
+function paletteInks(p: Palette) {
+  // "hair" is the hairline / band ink, "hot" is the ember (cell tint) ink.
+  const hair: [number, number, number] =
+    p === "light" ? [26, 26, 26] : [248, 247, 244];
+  // Hot ink (cell ember):
+  //  - light (paper): dark maroon — cells DARKEN the paper
+  //  - dark (near-black): pure black — cells get DARKER (greyscale push)
+  //  - oxblood: dusty rose — the only surface where a warm tint reads right
+  const hot: [number, number, number] =
+    p === "light" ? [73, 8, 45]
+    : p === "oxblood" ? [223, 174, 192]
+    : [0, 0, 0];
+  const bg =
+    p === "light" ? "#F8F7F4" : p === "oxblood" ? "#49082D" : "#1A1A1A";
+  // Tuned per ground:
+  //  - light (paper, behind hero right + How cards): pushed DARKER so the
+  //    ledger reads through the paper the way pencilled rulings would.
+  //  - dark (near-black, Verticals + Pain sections): dulled DOWN so the
+  //    ledger sits quietly under the demos rather than competing.
+  //  - oxblood (Get cards + Footer): also dulled DOWN for the same reason.
+  const baseLineAlpha = p === "light" ? 0.28 : p === "oxblood" ? 0.18 : 0.14;
+  const baseBandAlpha = p === "light" ? 0.08 : p === "oxblood" ? 0.06 : 0.04;
+  const maxStrengthBase = p === "light" ? 0.22 : 0.32;
+  const numeralColor = p === "light" ? "rgba(26,26,26,0.22)" : "rgba(248,247,244,0.18)";
+  const stampColor = p === "light" ? "#49082D" : "#DFAEC0";
+  return { hair, hot, bg, baseLineAlpha, baseBandAlpha, maxStrengthBase, numeralColor, stampColor };
+}
+
+interface CellState { v: number; tgt: number; }
+
+export default function LedgerScatter({ preset = "hero", groundColor }: LedgerScatterProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const palette = PRESET_PALETTE[preset];
+    const inks = paletteInks(palette);
+    const MAX_STRENGTH = inks.maxStrengthBase * MAX_STRENGTH_MULT;
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+    // Pointer state (in canvas pixels, relative to the canvas bounding box)
+    const pointer = { x: 0, y: 0, active: false };
+    const eased = { x: 0, y: 0, active: 0 };
+    const cells = new Map<string, CellState>();
+
+    let raf = 0;
+    let running = false;
+    let lastT = performance.now() / 1000;
+
+    function resize() {
+      if (!canvas || !container) return;
+      const r = container.getBoundingClientRect();
+      canvas.width = Math.max(1, Math.round(r.width * dpr));
+      canvas.height = Math.max(1, Math.round(r.height * dpr));
+      canvas.style.width = r.width + "px";
+      canvas.style.height = r.height + "px";
+      // Seed eased position at centre so the first ambient frames aren't
+      // drawn with a cursor way off-canvas.
+      if (eased.x === 0 && eased.y === 0) {
+        eased.x = canvas.width / 2;
+        eased.y = canvas.height / 2;
+      }
+    }
+
+    function draw(nowMs: number) {
+      if (!ctx || !canvas) return;
+      const t = nowMs / 1000;
+      const dt = Math.min(0.1, Math.max(0.001, t - lastT));
+      lastT = t;
+
+      const W = canvas.width;
+      const H = canvas.height;
+
+      const H_SP = H_SP_CSS * dpr;
+      const V_SP = V_SP_CSS * dpr;
+      const LEGACY_PERIOD = LEGACY_PERIOD_CSS * dpr;
+      const LEGACY_FILL = LEGACY_FILL_CSS * dpr;
+      const bandShift = BAND_OFFSET_FRAC * H_SP;
+
+      // ── Ease pointer toward target ────────────────────────────────────
+      const tx = pointer.active ? pointer.x * dpr : eased.x;
+      const ty = pointer.active ? pointer.y * dpr : eased.y;
+      eased.x += (tx - eased.x) * EASE_POS;
+      eased.y += (ty - eased.y) * EASE_POS;
+      const targetActive = pointer.active ? 1 : 0;
+      eased.active += (targetActive - eased.active) * 0.05;
+      const A = eased.active;
+
+      const cursorCol = Math.floor(eased.x / V_SP);
+      const cursorRow = Math.floor(eased.y / H_SP);
+
+      // ── Background ──
+      // If the caller passed groundColor, use it so the canvas doesn't
+      // re-paint the palette default over a container that's using a
+      // different tone (e.g. FooterBand on deep-shade maroon).
+      ctx.fillStyle = groundColor ?? inks.bg;
+      ctx.fillRect(0, 0, W, H);
+
+      // ── Ignite pass ────────────────────────────────────────────────────
+      if (A > 0.05) {
+        for (let dy = -RADIUS_CELLS; dy <= RADIUS_CELLS; dy++) {
+          for (let dx = -RADIUS_CELLS; dx <= RADIUS_CELLS; dx++) {
+            const d = Math.sqrt(dx * dx + dy * dy);
+            if (d > RADIUS_CELLS) continue;
+            const f0 = 1 - d / RADIUS_CELLS;
+            const fall = f0 * f0 * (3 - 2 * f0);
+            const perSec = IGNITE_BASE_PER_S * fall * A;
+            const p = 1 - Math.exp(-perSec * dt);
+            if (Math.random() < p) {
+              const col = cursorCol + dx;
+              const row = cursorRow + dy;
+              const x = col * V_SP;
+              const y = row * H_SP;
+              if (x + V_SP <= 0 || y + H_SP <= 0 || x >= W || y >= H) continue;
+              const key = col + "," + row;
+              const peak = 0.7 + Math.random() * 0.3;
+              const cur = cells.get(key);
+              if (cur) cur.tgt = Math.max(cur.tgt, peak);
+              else cells.set(key, { v: 0, tgt: peak });
+            }
+          }
+        }
+      }
+
+      // ── Row bands (static, band-offset shifted) ────────────────────────
+      ctx.fillStyle = `rgba(${inks.hair[0]},${inks.hair[1]},${inks.hair[2]},${inks.baseBandAlpha})`;
+      for (
+        let yTop = -LEGACY_PERIOD + bandShift;
+        yTop < H + LEGACY_PERIOD;
+        yTop += LEGACY_PERIOD
+      ) {
+        ctx.fillRect(0, yTop, W, LEGACY_FILL);
+      }
+
+      // ── Cell state update + paint ──────────────────────────────────────
+      for (const [key, s] of cells) {
+        s.tgt = Math.max(0, s.tgt - TGT_DECAY * dt);
+        if (s.tgt > s.v) {
+          s.v += (s.tgt - s.v) * (1 - Math.exp(-UP_RATE * dt));
+        } else {
+          s.v += (s.tgt - s.v) * (1 - Math.exp(-DOWN_RATE * dt));
+        }
+        if (s.v < 0.01 && s.tgt < 0.01) { cells.delete(key); continue; }
+        const [colStr, rowStr] = key.split(",");
+        const col = parseInt(colStr, 10);
+        const row = parseInt(rowStr, 10);
+        const x = col * V_SP;
+        const y = row * H_SP;
+        const alpha = s.v * MAX_STRENGTH;
+        ctx.fillStyle = `rgba(${inks.hot[0]},${inks.hot[1]},${inks.hot[2]},${alpha})`;
+        ctx.fillRect(x, y, V_SP, H_SP);
+      }
+
+      // ── Hairlines ──────────────────────────────────────────────────────
+      ctx.strokeStyle = `rgba(${inks.hair[0]},${inks.hair[1]},${inks.hair[2]},${inks.baseLineAlpha})`;
+      ctx.lineWidth = 1 * dpr;
+      ctx.beginPath();
+      for (let y0 = 0; y0 <= H; y0 += H_SP) {
+        ctx.moveTo(0, y0);
+        ctx.lineTo(W, y0);
+      }
+      for (let x0 = 0; x0 <= W; x0 += V_SP) {
+        ctx.moveTo(x0, 0);
+        ctx.lineTo(x0, H);
+      }
+      ctx.stroke();
+
+      raf = requestAnimationFrame(draw);
+    }
+
+    // Pointer wiring — listen on WINDOW (page-level) so foreground elements
+    // stacked over the canvas (demo cards, headlines, CTAs, etc.) don't
+    // block the ignites. The event is translated to canvas coordinates
+    // per-fire; if the cursor is outside this canvas's bounding rect the
+    // pointer goes inactive so the cells cool down naturally.
+    const onMove = (e: PointerEvent) => {
+      if (!canvas) return;
+      const r = canvas.getBoundingClientRect();
+      const x = e.clientX - r.left;
+      const y = e.clientY - r.top;
+      if (x < 0 || y < 0 || x > r.width || y > r.height) {
+        pointer.active = false;
+        return;
+      }
+      pointer.x = x;
+      pointer.y = y;
+      pointer.active = true;
+    };
+    const onLeaveWindow = () => { pointer.active = false; };
+
+    // Start/stop tied to viewport visibility so we don't render off-screen
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            if (!running) {
+              running = true;
+              resize();
+              window.addEventListener("pointermove", onMove, { passive: true });
+              window.addEventListener("pointerleave", onLeaveWindow);
+              lastT = performance.now() / 1000;
+              raf = requestAnimationFrame(draw);
+            }
+          } else if (running) {
+            running = false;
+            cancelAnimationFrame(raf);
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerleave", onLeaveWindow);
+            pointer.active = false;
+          }
+        }
+      },
+      { threshold: 0.02 }
+    );
+    io.observe(container);
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(container);
+
+    resize();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      io.disconnect();
+      ro.disconnect();
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerleave", onLeaveWindow);
+    };
+  }, [preset, groundColor]);
+
+  const inks = paletteInks(PRESET_PALETTE[preset]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        position: "absolute",
+        inset: 0,
+        overflow: "hidden",
+        pointerEvents: "none",
+      }}
+      aria-hidden
+    >
+      <canvas ref={canvasRef} style={{ display: "block", pointerEvents: "none" }} />
+      {/* Ledger's numeral column + corner stamp — stay put on top of the
+          reactive ruling so the whole thing reads as a printed document. */}
+      <div
+        style={{
+          position: "absolute",
+          left: 6,
+          top: 6,
+          bottom: 6,
+          width: 22,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          fontFamily:
+            'ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace',
+          fontSize: 8,
+          lineHeight: 1,
+          color: inks.numeralColor,
+          fontVariantNumeric: "tabular-nums",
+          padding: "8px 0",
+          pointerEvents: "none",
+        }}
+      >
+        {["01","02","03","04","05","06","07","08"].map((n) => (
+          <span key={n}>{n}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Landing/PainSection.tsx
+++ b/src/components/Landing/PainSection.tsx
@@ -3,7 +3,7 @@
 import { Box, Container, Text, Grid, Heading } from "@chakra-ui/react";
 import dynamic from "next/dynamic";
 
-const WireframeGrid = dynamic(() => import("./WireframeGrid"), { ssr: false });
+const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
 
 const NOISE_SVG = `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E")`;
 
@@ -57,7 +57,10 @@ export default function PainSection() {
       }}
     >
       {/* Wireframe grid behind the section */}
-      <WireframeGrid preset="pain" lineColor="#F8F7F4" />
+      <LedgerScatter preset="pain" />
+      {/* Dulling overlay — black on the near-black ink ground darkens it
+          straight without pulling the hue toward maroon. */}
+      <Box position="absolute" inset={0} pointerEvents="none" bg="rgba(0,0,0,0.55)" />
       {/* Feather grid edges into the ink bg on all 4 sides */}
       <Box
         position="absolute"
@@ -103,8 +106,6 @@ export default function PainSection() {
               borderColor="rgba(255,255,255,0.12)"
               borderRadius="12px"
               p={{ base: 6, md: 8 }}
-              transition="border-color 0.25s"
-              _hover={{ borderColor: "rgba(255,255,255,0.25)" }}
             >
               <Text
                 as="h3"

--- a/src/components/Landing/VerticalsSection.tsx
+++ b/src/components/Landing/VerticalsSection.tsx
@@ -6,7 +6,7 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import VerticalDemo from "./VerticalDemo";
 import dynamic from "next/dynamic";
 
-const WireframeGrid = dynamic(() => import("./WireframeGrid"), { ssr: false });
+const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
 
 type VerticalKey = "freight" | "procurement" | "vendor" | "hr" | "finance";
 
@@ -595,7 +595,9 @@ export default function VerticalsSection() {
             p={{ md: 8, lg: 10 }}
             borderRadius="20px"
           >
-            <WireframeGrid preset="verticals" lineColor="#F8F7F4" />
+            <LedgerScatter preset="verticals" />
+            {/* Dulling overlay — black on the near-black ink ground. */}
+            <Box position="absolute" inset={0} borderRadius="inherit" pointerEvents="none" bg="rgba(0,0,0,0.55)" />
             {/* Feather edges into section bg */}
             <Box
               position="absolute"


### PR DESCRIPTION
## Summary

Replaces the Three.js animated wireframe grid with a lighter, cursor-reactive **ledger** background across every section that used it. Cells near the eased cursor probabilistically ignite (with an ember trail) on top of a still ruled paper. Palette-aware per preset so cells DARKEN paper grounds and push toward black on ink grounds — no rose glow.

Ports the tuned config from the design exploration artifact.

## What changed

- **New component**: `src/components/Landing/LedgerScatter.tsx` — canvas-based, page-level pointer tracking so cells ignite through foreground cards and copy. Baked config from the tuning session (ignite 4.7 × dense 2.5, radius 3+1, upRate 15, downRate 1.8, tgtDecay 1, easePos 0.5, bandOffset 0.65, ambient breathing off, prevent re-ignite off, classic look off).
- **7 swap sites**: HeroSection, HowSection, GetSection, VerticalsSection, PainSection, FooterBand, Footer. All keep the same call signature (`preset`, `lineColor` accepted for parity).
- **Old `WireframeGrid.tsx` retained** so rollback is a one-line-per-file revert.
- **Composition polish**:
  - Dulling overlays on Pain / Verticals so the ledger sits under demos rather than competing.
  - `BookDemoSection` bottom padding tightened (`py 28` → `pt 28 / pb 10`) so the CTA copy hugs the footer strip.
  - Footer top feather widened (`transparent 20%` → `transparent 55%`) so the ledger's top edge dissolves smoothly into the CTA area above.
  - Removed the always-on hover border on Pain cards — they aren't clickable, so the highlight was misleading.
  - Removed the "Approved" corner stamp overlay from every ledger.

## Test plan

- [ ] Hero right half: ledger reads as pencilled rulings on paper; cursor darkens cells (no rose glow).
- [ ] How cards: ledger on paper card ground; cells darken; no bright-oxblood edge at the feathered card border.
- [ ] Get cards: ledger on oxblood ground with dusty-rose ember.
- [ ] Pain: ledger dulled to sit under the ink section; ember pushes cells toward black.
- [ ] Verticals: same treatment as Pain.
- [ ] Footer: ledger under the wordmark + links; top feather blends into the CTA above without a hard band; no bright ring where the feather ends.
- [ ] Cursor over a demo card / headline / CTA still drives the ignites (page-level pointer tracking).
- [ ] `npx tsc --noEmit` clean; `npm run lint` clean (only the pre-existing `GetDemos.tsx` warning that ships on main); `npx vitest run` 65/65 (one flaky timeout in `regression-findings.test.tsx` when the full suite runs cold; passes when re-run in isolation and unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gCGsXe7FDzkTWGZ9HJMfg