### PR TITLE
Hide thesis CTA, tighten footer seam, load ledger with initial payload

### DIFF
--- a/src/components/Landing/BookDemoSection.tsx
+++ b/src/components/Landing/BookDemoSection.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Box, Container, Text, Flex, Button, Link, Heading } from "@chakra-ui/react";
+import { Box, Container, Text, Flex, Button, Heading } from "@chakra-ui/react";
 import { getEarlyAccess } from "@/lib/utils";
 
 export default function BookDemoSection() {
   return (
-    <Box as="section" id="book-demo" pt={{ base: 14, md: 28 }} pb={{ base: 6, md: 10 }}>
+    <Box as="section" id="book-demo" pt={{ base: 14, md: 28 }} pb={{ base: 2, md: 4 }}>
       <Container maxW="container.xl" px={{ base: 4, sm: 6, md: 8, lg: 12 }}>
         <Heading
           as="h2"
@@ -51,16 +51,6 @@ export default function BookDemoSection() {
           >
             Become a design partner
           </Button>
-          <Link
-            href="/thesis"
-            color="surface.page"
-            fontWeight="600"
-            fontSize={{ base: "sm", md: "md" }}
-            _hover={{ textDecoration: "underline" }}
-            transition="all 0.2s"
-          >
-            Read the thesis first →
-          </Link>
         </Flex>
       </Container>
     </Box>

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -12,9 +12,7 @@ import {
 import NextLink from "next/link";
 import Image from "next/image";
 import { getEarlyAccess } from "@/lib/utils";
-import dynamic from "next/dynamic";
-
-const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
+import LedgerScatter from "./LedgerScatter";
 
 const FOOTER_LINKS = [
   { label: "Blog", href: "/blog" },

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -34,7 +34,7 @@ export default function Footer({ transparentBg = false }: { transparentBg?: bool
             position="absolute"
             inset={0}
             pointerEvents="none"
-            background="linear-gradient(to bottom, #49082D 0%, transparent 35%, transparent 80%, #49082D 100%)"
+            background="linear-gradient(to bottom, #49082D 0%, transparent 55%, transparent 85%, #49082D 100%)"
           />
         </>
       )}

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -25,10 +25,10 @@ const FOOTER_LINKS = [
 
 export default function Footer({ transparentBg = false }: { transparentBg?: boolean }) {
   return (
-    <Box as="footer" bg={transparentBg ? "transparent" : "brand.primary"} pt={{ base: 12, lg: 20 }} position="relative">
+    <Box as="footer" bg={transparentBg ? "transparent" : "brand.primary"} pt={{ base: 20, lg: 32 }} position="relative">
       {/* When the footer owns its background, it also owns the reactive
-          ledger — feathered into the maroon ground on all four sides, same
-          treatment we've always had here. */}
+          ledger — feathered top and bottom into the maroon ground so the
+          seam with the CTA above reads as one continuous surface. */}
       {!transparentBg && (
         <>
           <LedgerScatter preset="blog" />
@@ -36,18 +36,7 @@ export default function Footer({ transparentBg = false }: { transparentBg?: bool
             position="absolute"
             inset={0}
             pointerEvents="none"
-            _before={{
-              content: '""',
-              position: "absolute",
-              inset: 0,
-              background: "linear-gradient(to right, #49082D 0%, transparent 20%, transparent 80%, #49082D 100%)",
-            }}
-            _after={{
-              content: '""',
-              position: "absolute",
-              inset: 0,
-              background: "linear-gradient(to bottom, #49082D 0%, transparent 55%, transparent 85%, #49082D 100%)",
-            }}
+            background="linear-gradient(to bottom, #49082D 0%, transparent 35%, transparent 80%, #49082D 100%)"
           />
         </>
       )}

--- a/src/components/Landing/GetSection.tsx
+++ b/src/components/Landing/GetSection.tsx
@@ -7,9 +7,7 @@ import {
 } from "./GetDemos";
 import { UpdateDemo } from "./HowDemos";
 import { ConnectDemo } from "./ConnectDemo";
-import dynamic from "next/dynamic";
-
-const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
+import LedgerScatter from "./LedgerScatter";
 
 const cards = [
   {

--- a/src/components/Landing/GetSection.tsx
+++ b/src/components/Landing/GetSection.tsx
@@ -79,7 +79,7 @@ export default function GetSection() {
                 <Box
                   position="absolute"
                   inset={0}
-                  bg="rgba(73,8,45,0.88)"
+                  bg="rgba(73,8,45,0.65)"
                   pointerEvents="none"
                   zIndex={0}
                 />

--- a/src/components/Landing/HeroSection.tsx
+++ b/src/components/Landing/HeroSection.tsx
@@ -5,9 +5,7 @@ import { motion } from "motion/react";
 import { useState, useEffect } from "react";
 import { getEarlyAccess } from "@/lib/utils";
 import HeroDemo from "./HeroDemo";
-import dynamic from "next/dynamic";
-
-const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
+import LedgerScatter from "./LedgerScatter";
 
 const MotionBox = motion.create(Box);
 

--- a/src/components/Landing/HowSection.tsx
+++ b/src/components/Landing/HowSection.tsx
@@ -120,28 +120,39 @@ export default function HowSection() {
                   p={{ base: 0, md: 10, lg: 12 }}
                   borderRadius="20px"
                 >
-                  {/* Neat animated gradient behind card */}
-                  <LedgerScatter preset="how" />
-                  {/* Feather edges into page bg */}
+                  {/* Ledger + feather, outset beyond the padded card wrapper
+                      so a wider halo of ruling is visible without shrinking
+                      the demo card itself. Hidden on phones where the card
+                      spans full width and there is no room to outset. */}
                   <Box
+                    display={{ base: "none", md: "block" }}
                     position="absolute"
-                    inset={0}
-                    borderRadius="inherit"
+                    top={{ md: "-24px", lg: "-32px" }}
+                    bottom={{ md: "-24px", lg: "-32px" }}
+                    left={{ md: "-48px", lg: "-64px" }}
+                    right={{ md: "-48px", lg: "-64px" }}
                     pointerEvents="none"
                     zIndex={0}
-                    _before={{
-                      content: '""',
-                      position: "absolute",
-                      inset: 0,
-                      background: "linear-gradient(to right, #F8F7F4 0%, transparent 25%, transparent 75%, #F8F7F4 100%)",
-                    }}
-                    _after={{
-                      content: '""',
-                      position: "absolute",
-                      inset: 0,
-                      background: "linear-gradient(to bottom, #F8F7F4 0%, transparent 25%, transparent 75%, #F8F7F4 100%)",
-                    }}
-                  />
+                  >
+                    <LedgerScatter preset="how" />
+                    <Box
+                      position="absolute"
+                      inset={0}
+                      pointerEvents="none"
+                      _before={{
+                        content: '""',
+                        position: "absolute",
+                        inset: 0,
+                        background: "linear-gradient(to right, #F8F7F4 0%, transparent 18%, transparent 82%, #F8F7F4 100%)",
+                      }}
+                      _after={{
+                        content: '""',
+                        position: "absolute",
+                        inset: 0,
+                        background: "linear-gradient(to bottom, #F8F7F4 0%, transparent 18%, transparent 82%, #F8F7F4 100%)",
+                      }}
+                    />
+                  </Box>
                   <Box
                     position="relative"
                     border="2px solid"

--- a/src/components/Landing/HowSection.tsx
+++ b/src/components/Landing/HowSection.tsx
@@ -3,9 +3,7 @@
 import { Box, Container, Text, Flex, Heading } from "@chakra-ui/react";
 import { getEarlyAccess } from "@/lib/utils";
 import { CreateDemo, ViewDemo, RunDemo } from "./HowDemos";
-import dynamic from "next/dynamic";
-
-const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
+import LedgerScatter from "./LedgerScatter";
 
 const steps = [
   {

--- a/src/components/Landing/PainSection.tsx
+++ b/src/components/Landing/PainSection.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { Box, Container, Text, Grid, Heading } from "@chakra-ui/react";
-import dynamic from "next/dynamic";
-
-const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
+import LedgerScatter from "./LedgerScatter";
 
 const NOISE_SVG = `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E")`;
 

--- a/src/components/Landing/VerticalsSection.tsx
+++ b/src/components/Landing/VerticalsSection.tsx
@@ -4,9 +4,7 @@ import { Box, Container, Flex, Heading } from "@chakra-ui/react";
 import { getEarlyAccess } from "@/lib/utils";
 import { useState, useRef, useCallback, useEffect } from "react";
 import VerticalDemo from "./VerticalDemo";
-import dynamic from "next/dynamic";
-
-const LedgerScatter = dynamic(() => import("./LedgerScatter"), { ssr: false });
+import LedgerScatter from "./LedgerScatter";
 
 type VerticalKey = "freight" | "procurement" | "vendor" | "hr" | "finance";
 

--- a/src/components/Landing/__tests__/BookDemoSection.test.tsx
+++ b/src/components/Landing/__tests__/BookDemoSection.test.tsx
@@ -32,10 +32,10 @@ describe('BookDemoSection', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders the secondary CTA link', () => {
+  it('does not render a thesis link while the thesis page is unpublished', () => {
     render(<BookDemoSection />)
     expect(
-      screen.getByRole('link', { name: /Read the thesis first →/i })
-    ).toBeInTheDocument()
+      screen.queryByRole('link', { name: /Read the thesis first/i })
+    ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Stacks on top of #49.

## Summary
- Hide the "Read the thesis first →" CTA in the closing block — the thesis blog isn't published yet, so it was pointing at a 404.
- Rework the CTA/footer seam: cut the bottom padding on \`BookDemoSection\`, bump the footer's top padding, widen the top feather so the ledger blends up into the maroon ground, and drop the left/right feather so it runs edge-to-edge.
- Load \`LedgerScatter\` with the initial page payload instead of via \`next/dynamic({ ssr: false })\` in every consumer. It's already \`"use client"\` and only touches \`window\`/\`canvas\` inside \`useEffect\`, so the empty \`<canvas>\` SSRs fine — this stops the ledger from popping in as an afterthought after the surrounding section has already painted.

The hero's "Why are we building this? →" link still scrolls in-page to the \`#thesis\` MomentsSection, which is real on-page content, so it's left alone. If you meant that one should be hidden too, say the word.

## Test plan
- [ ] Closing CTA on desktop and phone shows only "Become a design partner" — no thesis link.
- [ ] The CTA + footer read as one continuous maroon slab; no visible band where the ledger begins.
- [ ] On hard reload every section's ledger paints together with the rest of the section — no late pop-in.
- [ ] \`npm test\` locally: 64/65 pass, same pre-existing flake on \`surface.page token resolves to #F8F7F4\` as #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gCGsXe7FDzkTWGZ9HJMfg