### PR TITLE
copy(landing): tighter hero, pain, how; brand-color text selection

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,3 +4,23 @@
 h1, h2, h3, h4, h5, h6 {
   font-variation-settings: "WONK" 0, "opsz" 144;
 }
+
+/* Text selection uses the brand color everywhere */
+::selection {
+  background: #49082D;
+  color: #F8F7F4;
+}
+::-moz-selection {
+  background: #49082D;
+  color: #F8F7F4;
+}
+
+/* On maroon-bg sections, invert: cream highlight, maroon text */
+[data-selection="inverse"] ::selection {
+  background: #F8F7F4;
+  color: #49082D;
+}
+[data-selection="inverse"] ::-moz-selection {
+  background: #F8F7F4;
+  color: #49082D;
+}

--- a/src/components/Landing/FooterBand.tsx
+++ b/src/components/Landing/FooterBand.tsx
@@ -13,10 +13,12 @@ import Footer from "./Footer";
 export default function FooterBand() {
   return (
     <>
-      <Box bg="brand.primary">
+      <Box bg="brand.primary" data-selection="inverse">
         <BookDemoSection />
       </Box>
-      <Footer />
+      <Box data-selection="inverse">
+        <Footer />
+      </Box>
     </>
   );
 }

--- a/src/components/Landing/GetSection.tsx
+++ b/src/components/Landing/GetSection.tsx
@@ -42,6 +42,7 @@ export default function GetSection() {
       as="section"
       py={{ base: 20, md: 28 }}
       bg="brand.primary"
+      data-selection="inverse"
     >
       <Container maxW="container.xl" px={{ base: 4, sm: 6, md: 8, lg: 12 }} position="relative">
         <Heading

--- a/src/components/Landing/HeroSection.tsx
+++ b/src/components/Landing/HeroSection.tsx
@@ -119,7 +119,7 @@ export default function HeroSection() {
               maxW="560px"
               mx={{ base: "auto", lg: "0" }}
             >
-              Describe your business processes and Colex turns them into rules and gets the job done. You get a written record of how your company decides things.
+              Describe your process. Colex turns it into rules, runs it, and writes down every decision.
             </Text>
 
             {/* Two CTAs */}

--- a/src/components/Landing/HowSection.tsx
+++ b/src/components/Landing/HowSection.tsx
@@ -8,21 +8,21 @@ import LedgerScatter from "./LedgerScatter";
 const steps = [
   {
     id: 1,
-    title: "Ask Colex to draft the rules in plain English",
+    title: "Describe the process. Colex writes the rules.",
     description:
-      "Colex turns it into rules over the evidence your process already produces.",
+      "Colex turns your process into simple computer rules. Things like “at least three quotes collected,” “invoice matches the order,” “customs approved.”",
   },
   {
     id: 2,
-    title: "Colex builds the interface from the rules for your team",
+    title: "Colex builds the screens your team works in.",
     description:
-      "Colex generates forms, tables, and views from the checks you defined. Your team can edit anything in it, and it updates when the rules change.",
+      "Forms to fill in, tables to review, buttons to approve, built from the same rules. Your team edits any value directly, and the screens change when the rules do.",
   },
   {
     id: 3,
-    title: "Colex does the work, your team verifies",
+    title: "Colex does the work, your team verifies.",
     description:
-      "Data fills in as Colex works. Your team reviews it, edits what needs editing, and approves when it looks right.",
+      "Colex uses agents and integrations to get the data ready for your team to review or edit, and waits for approval when needed.",
   },
 ];
 
@@ -61,7 +61,7 @@ export default function HowSection() {
               lineHeight={1.15}
               maxW="900px"
             >
-              You decide how it&rsquo;s done. Colex makes sure it gets done.
+              You decide the rules. Colex gets it done.
             </Heading>
           </Box>
           <Box

--- a/src/components/Landing/PainSection.tsx
+++ b/src/components/Landing/PainSection.tsx
@@ -8,31 +8,27 @@ const NOISE_SVG = `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='h
 // Title split so one load-bearing word carries the accent italic
 const cards = [
   {
-    title: ["Exceptions taught it ", "nothing", ""],
+    title: ["People end up doing it their ", "own way", "."],
     lines: [
-      "Every edge case went to a person and got handled in chat.",
-      "Next month the same exception showed up, and nobody remembered.",
+      "You wrote the process. Getting the team (or the agents) to follow it is the hard part.",
     ],
   },
   {
-    title: ["The document isn’t the ", "process", ""],
+    title: ["Automating it is expensive. Updating it? ", "Double", "."],
     lines: [
-      "It lives in a file written months ago.",
-      "The real process lives in dozens of decisions people make every day.",
+      "You put the process in a tool. The work changes, and you pay the engineering bill again to make the tool match.",
     ],
   },
   {
-    title: ["When something breaks, no one knows ", "where", ""],
+    title: ["You can’t see what ", "actually", " happened."],
     lines: [
-      "You can see the outcome was wrong.",
-      "Finding the answer means asking five people who each remember the process differently.",
+      "When something goes wrong, you have the outcome but not the run. To find out, you ask whoever touched it what they remember.",
     ],
   },
   {
-    title: ["Change is ", "expensive", " and slow"],
+    title: ["You are your team’s ", "memory", "."],
     lines: [
-      "One rule change touches five systems.",
-      "By the time it’s live, the process has moved on.",
+      "Docs hold the process, logs hold the data. The reasoning is in your head.",
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- Rewrote hero lede, all four Pain cards (from ops-team interview points), and all three How-section step titles/descriptions — cutting stock phrases and passive voice, naming the concrete failure and the concrete example.
- Added brand-maroon text selection site-wide, inverted (cream-on-maroon) inside GetSection and FooterBand via a `data-selection="inverse"` attribute.

## Test plan
- [ ] `npm run dev` and eyeball hero, `#why-colex`, and How section — copy reads as intended
- [ ] Select text on cream-bg sections — highlight is maroon
- [ ] Select text inside the maroon "Get" section and the footer — highlight is cream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMPzodg3NR5uwpkEwGABdS