### PR TITLE
copy(landing): rework Get cards; new Pain heading + card 2 title

### DIFF
--- a/src/components/Landing/GetSection.tsx
+++ b/src/components/Landing/GetSection.tsx
@@ -25,7 +25,7 @@ const cards = [
   {
     title: "Take back a decision.",
     description:
-      "You approved something on Monday. On Thursday you realise it shouldn’t have been. Undo it, and everything that followed goes back into review. Most automation tools don’t let you do that.",
+      "You approved something on Monday. On Thursday you realise it shouldn’t have been. Undo it, and everything that followed goes back into review.",
     Demo: RewindDemo,
   },
   {

--- a/src/components/Landing/GetSection.tsx
+++ b/src/components/Landing/GetSection.tsx
@@ -11,27 +11,27 @@ import LedgerScatter from "./LedgerScatter";
 
 const cards = [
   {
-    title: "Plug into the tools you already use",
+    title: "Works with the tools you already use.",
     description:
-      "Email, Slack, ERPs, spreadsheets. Colex connects where your data already lives.",
+      "Email, Slack, ERPs, spreadsheets. Colex reads from and writes to whatever your process already touches.",
     Demo: ConnectDemo,
   },
   {
-    title: "Change the rules, the workflow follows",
+    title: "Change a rule, the workflow catches up.",
     description:
-      "Edit a rule and the running workflow updates in seconds. No rebuild, no retraining.",
+      "Edit any rule and the running workflow updates in seconds. No rebuild, no retraining.",
     Demo: UpdateDemo,
   },
   {
-    title: "Work that rewinds when things change",
+    title: "Take back a decision.",
     description:
-      "Customs rejects an entry on Thursday. Monday’s “done” reopens and goes back into review.",
+      "You approved something on Monday. On Thursday you realise it shouldn’t have been. Undo it, and everything that followed goes back into review. Most automation tools don’t let you do that.",
     Demo: RewindDemo,
   },
   {
-    title: "All your rules written down, all action auditable",
+    title: "Every rule and every action, written down.",
     description:
-      "Versioned, inspectable, and yours to reason over, not buried inside a workflow where nobody can find them.",
+      "Every rule change, every decision, every run, kept in one place your team can open and read. Not buried inside a workflow nobody can get into.",
     Demo: AuditDemo,
   },
 ];

--- a/src/components/Landing/MomentsSection.tsx
+++ b/src/components/Landing/MomentsSection.tsx
@@ -100,7 +100,7 @@ export default function MomentsSection() {
         <Text
           color="ink.muted"
           fontSize={{ base: "md", md: "lg" }}
-          mb={{ base: 10, md: 14 }}
+          mb={{ base: 8, md: 14 }}
           maxW="640px"
         >
           Other automation tools leave you with rigid workflows which decay. Colex grows with you continuously.

--- a/src/components/Landing/PainSection.tsx
+++ b/src/components/Landing/PainSection.tsx
@@ -14,7 +14,7 @@ const cards = [
     ],
   },
   {
-    title: ["Automating it is expensive. Updating it? ", "Double", "."],
+    title: ["Automating is expensive. Change is a ", "headache", "."],
     lines: [
       "You put the process in a tool. The work changes, and you pay the engineering bill again to make the tool match.",
     ],
@@ -85,7 +85,7 @@ export default function PainSection() {
           letterSpacing="-0.02em"
           mb={{ base: 10, md: 14 }}
         >
-          You wrote the process. It still isn&rsquo;t being followed.
+          Running ops is difficult. Automating, doubly so.
         </Heading>
 
         <Grid

--- a/src/components/Landing/VerticalsSection.tsx
+++ b/src/components/Landing/VerticalsSection.tsx
@@ -334,8 +334,10 @@ export default function VerticalsSection() {
         </Heading>
 
         {/* Tabs — wrap on mobile too now; the pills are a readout of which
-            tab the carousel is currently on, not a separate scrolling axis. */}
-        <Box position="relative" mb={{ base: 4, md: 6 }}>
+            tab the carousel is currently on, not a separate scrolling axis.
+            zIndex bumped so the desktop ledger's outset halo (which pokes
+            leftward from the demo column) can't paint over the pills. */}
+        <Box position="relative" zIndex={2} mb={{ base: 4, md: 6 }}>
           <Flex
             role="tablist"
             aria-label="Industry verticals"

--- a/src/components/Landing/VerticalsSection.tsx
+++ b/src/components/Landing/VerticalsSection.tsx
@@ -330,14 +330,14 @@ export default function VerticalsSection() {
           textAlign="left"
           mb={{ base: 4, md: 6 }}
         >
-          For the teams that run a company day to day.
+          Built for ops teams who want to be AI-first, not eventually.
         </Heading>
 
         {/* Tabs — wrap on mobile too now; the pills are a readout of which
             tab the carousel is currently on, not a separate scrolling axis.
             zIndex bumped so the desktop ledger's outset halo (which pokes
             leftward from the demo column) can't paint over the pills. */}
-        <Box position="relative" zIndex={2} mb={{ base: 4, md: 6 }}>
+        <Box position="relative" zIndex={2} mb={{ base: 8, md: 14 }}>
           <Flex
             role="tablist"
             aria-label="Industry verticals"


### PR DESCRIPTION
## Summary
- Rewrote all four **Get section** cards in plain ops language. Connect, Update, Rewind (now "Take back a decision" with an approved-Monday / undo-Thursday moment), and Audit (drops the "versioned, inspectable, reason over" jargon).
- New **Pain section heading** — "Running ops is difficult. Automating, doubly so." — names the audience directly.
- New **Pain card 2 title** — "Automating is expensive. Change is a headache." Body preserved.

## Test plan
- [ ] `npm run dev` and eyeball the Pain (`#why-colex`) and Get sections
- [ ] Card 3 in Get ("Take back a decision") reads clearly on the maroon bg
- [ ] All titles/bodies wrap sensibly at 390 / 768 / 1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMPzodg3NR5uwpkEwGABdS