### PR TITLE
copy(landing): meta title/description + Moments heading + sub

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,13 +6,13 @@ import Providers from "./providers";
 import LayoutClient from "./LayoutClient";
 
 export const metadata = {
-  title: "Colex | Simple workflows",
+  title: "Colex — Ops automation that grows with your business",
   description:
-    "Give your teams extra hands. Purpose-built to automate your team reliably.",
+    "Describe your process. Colex turns it into rules, runs it, and writes down every decision.",
   openGraph: {
-    title: "Colex | Simple workflows",
+    title: "Colex — Ops automation that grows with your business",
     description:
-      "Give your teams extra hands. Purpose-built to automate your team reliably.",
+      "Describe your process. Colex turns it into rules, runs it, and writes down every decision.",
     url: "https://getcolex.com/",
     siteName: "Colex",
     locale: "en_US",
@@ -20,9 +20,9 @@ export const metadata = {
   },
   twitter: {
     card: "summary",
-    title: "Colex | Simple workflows",
+    title: "Colex — Ops automation that grows with your business",
     description:
-      "Give your teams extra hands. Purpose-built to automate your team reliably.",
+      "Describe your process. Colex turns it into rules, runs it, and writes down every decision.",
   },
   metadataBase: new URL("https://getcolex.com"),
 };

--- a/src/components/Landing/MomentsSection.tsx
+++ b/src/components/Landing/MomentsSection.tsx
@@ -94,7 +94,7 @@ export default function MomentsSection() {
           letterSpacing="-0.02em"
           mb={{ base: 4, md: 6 }}
         >
-          Six months in, you own something.
+          Your business changes. Your software should too.
         </Heading>
 
         <Text
@@ -103,7 +103,7 @@ export default function MomentsSection() {
           mb={{ base: 8, md: 14 }}
           maxW="640px"
         >
-          Other automation tools leave you with rigid workflows which decay. Colex grows with you continuously.
+          Rules shift, teams grow, priorities move. Colex changes with all of it, without a rebuild.
         </Text>
 
         {/* ── Desktop layout ── */}


### PR DESCRIPTION
## Summary
- **Meta title** — "Colex — Ops automation that grows with your business" (replaces "Colex | Simple workflows"). Updated across the base title, openGraph, and twitter blocks.
- **Meta description** — now mirrors the current hero lede: "Describe your process. Colex turns it into rules, runs it, and writes down every decision." (Was still selling the old "extra hands" line that has been off the hero for a while.)
- **Moments heading** — "Your business changes. Your software should too." (replaces "Six months in, you own something.").
- **Moments sub** — "Rules shift, teams grow, priorities move. Colex changes with all of it, without a rebuild." (drops the stock-SaaS "rigid workflows which decay" line).

## Test plan
- [ ] `npm run dev` — meta title shows in the browser tab
- [ ] Moments section reads as a promise (`heading`) → concrete list (`sub`) → paired table below
- [ ] OG image / share preview picks up the new description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMPzodg3NR5uwpkEwGABdS