### PR TITLE
feat(pain): flip-deck replaces 2×2 grid; mobile How CTA

### DIFF
--- a/src/components/Landing/HowSection.tsx
+++ b/src/components/Landing/HowSection.tsx
@@ -68,21 +68,21 @@ export default function HowSection() {
             as="button"
             onClick={() => getEarlyAccess("how_section")}
             cursor="pointer"
-            display="inline-flex"
+            display={{ base: "none", md: "inline-flex" }}
             alignItems="center"
             justifyContent="center"
-            w={{ base: "full", md: "auto" }}
+            w="auto"
             bg="brand.primary"
             color="white"
-            px={{ base: 4, md: 6 }}
+            px={6}
             py={3}
             borderRadius="8px"
             fontWeight="600"
-            fontSize={{ base: "sm", md: "md" }}
+            fontSize="md"
             textDecoration="none"
             transition="all 0.2s"
             whiteSpace="nowrap"
-            mt={{ base: 0, md: 2 }}
+            mt={2}
             _hover={{
               opacity: 0.9,
               transform: "translateY(-2px)",
@@ -210,6 +210,36 @@ export default function HowSection() {
             );
           })}
         </Flex>
+
+        {/* Mobile-only CTA — the desktop CTA sits in the header row.
+            On phones we surface it below the cards so the reader ends
+            on the action rather than scrolling past a header button. */}
+        <Box
+          as="button"
+          onClick={() => getEarlyAccess("how_section_mobile")}
+          cursor="pointer"
+          display={{ base: "inline-flex", md: "none" }}
+          alignItems="center"
+          justifyContent="center"
+          w="full"
+          bg="brand.primary"
+          color="white"
+          px={4}
+          py={3}
+          mt={10}
+          borderRadius="8px"
+          fontWeight="600"
+          fontSize="sm"
+          textDecoration="none"
+          transition="all 0.2s"
+          _hover={{
+            opacity: 0.9,
+            transform: "translateY(-2px)",
+            textDecoration: "none",
+          }}
+        >
+          Get a personalised demo &rarr;
+        </Box>
       </Container>
     </Box>
   );

--- a/src/components/Landing/PainSection.tsx
+++ b/src/components/Landing/PainSection.tsx
@@ -1,129 +1,276 @@
 "use client";
 
-import { Box, Container, Text, Grid, Heading } from "@chakra-ui/react";
+import { Box, Container, Text, Heading } from "@chakra-ui/react";
+import { motion } from "motion/react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import LedgerScatter from "./LedgerScatter";
 
-const NOISE_SVG = `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E")`;
+const MotionBox = motion.create(Box);
 
-// Title split so one load-bearing word carries the accent italic
+// Load-bearing word gets the accent color (upright, not italic).
 const cards = [
   {
     title: ["People end up doing it their ", "own way", "."],
-    lines: [
-      "You wrote the process. Getting the team (or the agents) to follow it is the hard part.",
-    ],
+    body: "You wrote the process. Getting the team (or the agents) to follow it is the hard part.",
   },
   {
     title: ["Automating is expensive. Change is a ", "headache", "."],
-    lines: [
-      "You put the process in a tool. The work changes, and you pay the engineering bill again to make the tool match.",
-    ],
+    body: "You put the process in a tool. The work changes, and you pay the engineering bill again to make the tool match.",
   },
   {
     title: ["You can’t see what ", "actually", " happened."],
-    lines: [
-      "When something goes wrong, you have the outcome but not the run. To find out, you ask whoever touched it what they remember.",
-    ],
+    body: "When something goes wrong, you have the outcome but not the run. To find out, you ask whoever touched it what they remember.",
   },
   {
     title: ["You are your team’s ", "memory", "."],
-    lines: [
-      "Docs hold the process, logs hold the data. The reasoning is in your head.",
-    ],
+    body: "Docs hold the process, logs hold the data. The reasoning is in your head.",
   },
 ];
 
+const ACCENT = "#C9909F";
+
+// Positional variants for the four deck cards. Front = pos0.
+// Desktop: fanned right; mobile: gentler fan.
+const desktopPositions = [
+  { x: -40, y: 0, rot: -2, opacity: 1, brightness: 1, z: 4 },
+  { x: 0, y: -4, rot: 3, opacity: 0.9, brightness: 0.9, z: 3 },
+  { x: 38, y: -8, rot: 8, opacity: 0.7, brightness: 0.75, z: 2 },
+  { x: 72, y: -14, rot: 13, opacity: 0.5, brightness: 0.6, z: 1 },
+];
+
+const mobilePositions = [
+  { x: -20, y: 0, rot: -1, opacity: 1, brightness: 1, z: 4 },
+  { x: 0, y: -4, rot: 2, opacity: 0.9, brightness: 0.9, z: 3 },
+  { x: 20, y: -8, rot: 4, opacity: 0.7, brightness: 0.75, z: 2 },
+  { x: 38, y: -14, rot: 6, opacity: 0.5, brightness: 0.6, z: 1 },
+];
+
+function useIsDesktop(bp = 768) {
+  const [is, setIs] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia(`(min-width: ${bp}px)`);
+    const on = () => setIs(mq.matches);
+    on();
+    mq.addEventListener("change", on);
+    return () => mq.removeEventListener("change", on);
+  }, [bp]);
+  return is;
+}
+
 export default function PainSection() {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const hoveringRef = useRef(false);
+  const inViewRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isDesktop = useIsDesktop();
+
+  const advance = useCallback(() => setActiveIdx((i) => (i + 1) % cards.length), []);
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+  const startTimer = useCallback(() => {
+    if (timerRef.current) return;
+    if (!inViewRef.current || hoveringRef.current) return;
+    timerRef.current = setInterval(() => {
+      setActiveIdx((i) => (i + 1) % cards.length);
+    }, 7000);
+  }, []);
+
+  // Autoplay on visibility, pause on hover.
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const ent of entries) {
+          inViewRef.current = ent.isIntersecting;
+          if (ent.isIntersecting) startTimer();
+          else stopTimer();
+        }
+      },
+      { threshold: 0.4 }
+    );
+    io.observe(el);
+    return () => {
+      io.disconnect();
+      stopTimer();
+    };
+  }, [startTimer, stopTimer]);
+
+  const positions = isDesktop ? desktopPositions : mobilePositions;
+  const counter = String(activeIdx + 1).padStart(2, "0");
+
   return (
     <Box
       as="section"
       id="why-colex"
-      py={{ base: 20, md: 28 }}
-      bg="ink.primary"
+      py={{ base: 8, md: 10 }}
+      bg="surface.page"
       position="relative"
-      _after={{
-        content: '""',
-        position: "absolute",
-        inset: 0,
-        backgroundImage: NOISE_SVG,
-        backgroundRepeat: "repeat",
-        pointerEvents: "none",
-      }}
     >
-      {/* Wireframe grid behind the section */}
-      <LedgerScatter preset="pain" />
-      {/* Dulling overlay — black on the near-black ink ground darkens it
-          straight without pulling the hue toward maroon. */}
-      <Box position="absolute" inset={0} pointerEvents="none" bg="rgba(0,0,0,0.35)" />
-      {/* Feather grid edges into the ink bg on all 4 sides */}
-      <Box
-        position="absolute"
-        inset={0}
-        pointerEvents="none"
-        _before={{
-          content: '""',
-          position: "absolute",
-          inset: 0,
-          background:
-            "linear-gradient(to right, #1A1A1A 0%, transparent 20%, transparent 80%, #1A1A1A 100%)",
-        }}
-        _after={{
-          content: '""',
-          position: "absolute",
-          inset: 0,
-          background:
-            "linear-gradient(to bottom, #1A1A1A 0%, transparent 20%, transparent 80%, #1A1A1A 100%)",
-        }}
-      />
-      <Container maxW="container.xl" px={{ base: 4, sm: 6, md: 8, lg: 12 }} position="relative" zIndex={1}>
-        <Heading
-          as="h2"
-          fontFamily="heading"
-          fontSize={{ base: "3xl", md: "4xl", lg: "5xl" }}
-          fontWeight="700"
-          color="surface.page"
-          letterSpacing="-0.02em"
-          mb={{ base: 10, md: 14 }}
+      <Container
+        maxW="container.xl"
+        px={{ base: 4, sm: 6, md: 8, lg: 12 }}
+        position="relative"
+        zIndex={1}
+      >
+        <Box
+          ref={wrapRef}
+          tabIndex={0}
+          role="group"
+          aria-label="Four things ops teams tell us after they have tried to automate"
+          onClick={advance}
+          onMouseEnter={() => {
+            hoveringRef.current = true;
+            stopTimer();
+          }}
+          onMouseLeave={() => {
+            hoveringRef.current = false;
+            startTimer();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowRight" || e.key === "ArrowLeft" || e.key === " " || e.key === "Enter") {
+              e.preventDefault();
+              advance();
+            }
+          }}
+          w="100%"
+          bg="#101010"
+          borderRadius="20px"
+          p={{ base: 8, md: 14 }}
+          display="grid"
+          gridTemplateColumns={{ base: "1fr", md: "1fr 1fr" }}
+          gap={{ base: 10, md: 12 }}
+          alignItems="center"
+          position="relative"
+          overflow="hidden"
+          cursor="pointer"
+          boxShadow="0 40px 120px -40px rgba(0,0,0,0.28), inset 0 1px 0 rgba(255,255,255,0.05)"
+          transition="all 0.4s cubic-bezier(0.2, 0.9, 0.3, 1)"
+          _hover={{
+            transform: "translateY(-6px)",
+            boxShadow:
+              "0 60px 140px -40px rgba(0,0,0,0.4), 0 0 0 1px rgba(201,144,159,0.18), inset 0 1px 0 rgba(255,255,255,0.05)",
+          }}
+          _focusVisible={{
+            outline: "2px solid",
+            outlineColor: ACCENT,
+            outlineOffset: "2px",
+          }}
         >
-          Running ops is difficult. Automating, doubly so.
-        </Heading>
+          {/* Ledger backdrop inside the card */}
+          <Box position="absolute" inset={0} pointerEvents="none" zIndex={0}>
+            <LedgerScatter preset="pain" />
+          </Box>
 
-        <Grid
-          templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }}
-          gap={{ base: 4, lg: 6 }}
-        >
-          {cards.map((card) => (
-            <Box
-              key={card.title.join("")}
-              bg="#242424"
-              border="1px solid"
-              borderColor="rgba(255,255,255,0.12)"
-              borderRadius="12px"
-              p={{ base: 6, md: 8 }}
+          {/* Left column */}
+          <Box position="relative" zIndex={1} display="flex" flexDirection="column" gap={6}>
+            <Heading
+              as="h2"
+              fontFamily="heading"
+              fontWeight="700"
+              fontSize={{ base: "3xl", md: "4xl", lg: "5xl" }}
+              color="surface.page"
+              letterSpacing="-0.02em"
+              lineHeight={1.15}
+              m={0}
             >
-              <Text
-                as="h3"
-                fontFamily="heading"
-                fontSize={{ base: "xl", md: "2xl" }}
-                fontWeight="600"
-                color="surface.page"
-                lineHeight={1.3}
-                mb={4}
-              >
-                {card.title[0]}
-                <Box as="em" fontStyle="italic" color="#C9909F">
-                  {card.title[1]}
-                </Box>
-                {card.title[2]}
-              </Text>
-              {card.lines.map((line) => (
-                <Text key={line} fontSize={{ base: "sm", md: "md" }} color="border.default" mb={1.5}>
-                  {line}
-                </Text>
-              ))}
-            </Box>
-          ))}
-        </Grid>
+              Running ops is difficult. Automating, doubly so.
+            </Heading>
+            <Text
+              as="span"
+              fontFamily="mono"
+              fontSize="11px"
+              letterSpacing="0.16em"
+              textTransform="uppercase"
+              color="surface.page"
+              mt={2}
+              style={{ fontVariantNumeric: "tabular-nums" }}
+            >
+              {counter} / 04
+            </Text>
+          </Box>
+
+          {/* Right column — perspective / deck */}
+          <MotionBox
+            position="relative"
+            zIndex={1}
+            height={{ base: "240px", md: "260px" }}
+            style={{ perspective: "1200px", touchAction: "pan-y" }}
+            onPanEnd={(_, info) => {
+              // Horizontal swipe past ~50px, or a flick with speed > 500
+              if (Math.abs(info.offset.x) > 50 || Math.abs(info.velocity.x) > 500) {
+                advance();
+              }
+            }}
+          >
+            {cards.map((card, idx) => {
+              const posIdx = (idx - activeIdx + cards.length) % cards.length;
+              const p = positions[posIdx];
+              return (
+                <MotionBox
+                  key={card.title.join("")}
+                  position="absolute"
+                  top="50%"
+                  left="50%"
+                  width={{ base: "280px", md: "360px" }}
+                  minHeight={{ base: "240px", md: "260px" }}
+                  height="auto"
+                  bg="#1E1E1E"
+                  border="1px solid rgba(248,247,244,0.10)"
+                  borderRadius="12px"
+                  padding="22px 24px"
+                  boxShadow="0 24px 40px -20px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.04)"
+                  display="flex"
+                  flexDirection="column"
+                  gap={3}
+                  color="rgba(248,247,244,0.85)"
+                  style={{ transformOrigin: "center center", willChange: "transform, opacity" }}
+                  initial={false}
+                  animate={{
+                    x: `calc(-50% + ${p.x}px)`,
+                    y: `calc(-50% + ${p.y}px)`,
+                    rotate: p.rot,
+                    opacity: p.opacity,
+                    filter: `brightness(${p.brightness})`,
+                  }}
+                  transition={{ duration: 0.55, ease: [0.2, 0.9, 0.3, 1] }}
+                  zIndex={p.z}
+                >
+                  <Text
+                    as="h3"
+                    fontFamily="heading"
+                    fontWeight="600"
+                    fontSize={{ base: "xl", md: "2xl" }}
+                    color="surface.page"
+                    lineHeight={1.3}
+                    mb={3}
+                  >
+                    {card.title[0]}
+                    <Box as="span" color={ACCENT}>
+                      {card.title[1]}
+                    </Box>
+                    {card.title[2]}
+                  </Text>
+                  <Text
+                    fontFamily="body"
+                    fontWeight="400"
+                    fontSize={{ base: "sm", md: "md" }}
+                    color="rgba(248,247,244,0.72)"
+                    lineHeight={1.7}
+                  >
+                    {card.body}
+                  </Text>
+                </MotionBox>
+              );
+            })}
+          </MotionBox>
+        </Box>
       </Container>
     </Box>
   );


### PR DESCRIPTION
## Summary
- **Pain section rebuilt as a landscape flip-deck.** Dropped the full-width dark band, dropped the section-level ledger + noise + dulling + edge feather. Section now uses `surface.page` (paper) so the single dark card floats between the paper Hero and paper How sections as a bridge, not a floor.
- The card has `LedgerScatter preset="pain"` inside it as backdrop. Left column: Fraunces h2 + `01 / 04` counter. Right column: four deck cards fanned right with framer-motion; front card shows the current pain (claim + body, no tags, no artifacts).
- **Interactions:** tap anywhere on the outer card advances, arrow keys / Space / Enter also advance, horizontal swipe on the deck advances (touch), autoplay every 7s when in view, pauses on hover. Cards render at their fanned positions on first paint (`initial={false}`) — no fly-in.
- **Type back on convention:** card h3 = `xl/2xl` weight 600, lineHeight 1.3; body = `sm/md` lineHeight 1.7; h2 lineHeight 1.15. Matches How and Get.
- **How section:** on phones the `Get a personalised demo` CTA moves from the header row to a full-width button below the last How card.

## Test plan
- [ ] `npm run dev` — Pain section reads as a bridge between Hero and How
- [ ] Desktop: tap card advances; arrow keys advance; autoplay ticks every 7s; hovering pauses
- [ ] Mobile 390px: card stacks vertical; swipe advances; tap advances; How CTA sits below the last How card, full width
- [ ] Reactive ledger visible inside the dark card
- [ ] First paint: cards start at their fanned positions, no fly-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMPzodg3NR5uwpkEwGABdS