### PR TITLE
fix: recover lost demo/ledger/pills commits + Pain timer

### DIFF
--- a/src/components/Landing/ConnectDemo.tsx
+++ b/src/components/Landing/ConnectDemo.tsx
@@ -268,7 +268,7 @@ export function ConnectDemo() {
           transition={{ duration: 0.3 }}
           display="flex"
           flexDirection="column"
-          justifyContent="center"
+          justifyContent="flex-start"
           h="100%"
         >
           {/* Header */}

--- a/src/components/Landing/GetDemos.tsx
+++ b/src/components/Landing/GetDemos.tsx
@@ -309,7 +309,7 @@ export function RewindDemo() {
 
   return (
     <DemoContainer containerRef={ref} variant="maroon" flush>
-      <Flex direction="column" h="100%" gap={0} justify="center">
+      <Flex direction="column" h="100%" gap={0} justify="flex-start">
         {/* Goal header with count */}
         <Flex justify="space-between" align="center" mb={3}>
           <Flex align="center" gap={2}>
@@ -516,11 +516,9 @@ export function AuditDemo() {
 
   return (
     <DemoContainer containerRef={ref} variant="maroon" flush>
-      {/* justify="center" keeps this small, fixed-content demo (header + 2
-          rules, occasionally + version badge/audit line) as one centered
-          mass in the panel instead of pinned to the top with a growing void
-          below it. */}
-      <Flex direction="column" justify="center" h="100%" gap={0}>
+      {/* Top-anchored so new items (version badge / audit line) appear
+          below existing content instead of pushing everything center-out. */}
+      <Flex direction="column" justify="flex-start" h="100%" gap={0}>
         {/* Section header — check editor style */}
         <Flex justify="space-between" align="center" mb={3}>
           <Text

--- a/src/components/Landing/HowDemos.tsx
+++ b/src/components/Landing/HowDemos.tsx
@@ -1261,9 +1261,9 @@ export function UpdateDemo() {
 
   return (
     <DemoContainer containerRef={rootRef} variant="maroon" flush>
-      {/* Center+distribute at every width — top-anchoring left a dead gap
-          under the form box on desktop panel heights too. */}
-      <Flex direction="column" flex="1" justifyContent="center" gap={{ base: 4, md: 3 }}>
+      {/* Top-anchored so newly-appearing task/form sections stack downward
+          instead of expanding around the vertical midpoint. */}
+      <Flex direction="column" flex="1" justifyContent="flex-start" gap={{ base: 4, md: 3 }}>
       {/* Rule section */}
       <Box>
       <SectionHeader dark>Rule updated</SectionHeader>

--- a/src/components/Landing/LedgerScatter.tsx
+++ b/src/components/Landing/LedgerScatter.tsx
@@ -72,12 +72,12 @@ function paletteInks(p: Palette) {
     p === "light" ? [26, 26, 26] : [248, 247, 244];
   // Hot ink (cell ember):
   //  - light (paper): dark maroon — cells DARKEN the paper
-  //  - dark (near-black): pure black — cells get DARKER (greyscale push)
+  //  - dark (near-black): cream — cells LIGHTEN the near-black
   //  - oxblood: dusty rose — the only surface where a warm tint reads right
   const hot: [number, number, number] =
     p === "light" ? [73, 8, 45]
     : p === "oxblood" ? [223, 174, 192]
-    : [0, 0, 0];
+    : [248, 247, 244];
   const bg =
     p === "light" ? "#F8F7F4" : p === "oxblood" ? "#49082D" : "#1A1A1A";
   // Tuned per ground:
@@ -88,7 +88,7 @@ function paletteInks(p: Palette) {
   //  - oxblood (Get cards + Footer): also dulled DOWN for the same reason.
   const baseLineAlpha = p === "light" ? 0.28 : p === "oxblood" ? 0.18 : 0.14;
   const baseBandAlpha = p === "light" ? 0.08 : p === "oxblood" ? 0.06 : 0.04;
-  const maxStrengthBase = p === "light" ? 0.22 : 0.32;
+  const maxStrengthBase = p === "light" ? 0.22 : p === "oxblood" ? 0.32 : 0.14;
   const numeralColor = p === "light" ? "rgba(26,26,26,0.22)" : "rgba(248,247,244,0.18)";
   const stampColor = p === "light" ? "#49082D" : "#DFAEC0";
   return { hair, hot, bg, baseLineAlpha, baseBandAlpha, maxStrengthBase, numeralColor, stampColor };
@@ -304,8 +304,6 @@ export default function LedgerScatter({ preset = "hero", groundColor }: LedgerSc
     };
   }, [preset, groundColor]);
 
-  const inks = paletteInks(PRESET_PALETTE[preset]);
-
   return (
     <div
       ref={containerRef}
@@ -318,32 +316,6 @@ export default function LedgerScatter({ preset = "hero", groundColor }: LedgerSc
       aria-hidden
     >
       <canvas ref={canvasRef} style={{ display: "block", pointerEvents: "none" }} />
-      {/* Ledger's numeral column + corner stamp — stay put on top of the
-          reactive ruling so the whole thing reads as a printed document. */}
-      <div
-        style={{
-          position: "absolute",
-          left: 6,
-          top: 6,
-          bottom: 6,
-          width: 22,
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-between",
-          fontFamily:
-            'ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace',
-          fontSize: 8,
-          lineHeight: 1,
-          color: inks.numeralColor,
-          fontVariantNumeric: "tabular-nums",
-          padding: "8px 0",
-          pointerEvents: "none",
-        }}
-      >
-        {["01","02","03","04","05","06","07","08"].map((n) => (
-          <span key={n}>{n}</span>
-        ))}
-      </div>
     </div>
   );
 }

--- a/src/components/Landing/PainSection.tsx
+++ b/src/components/Landing/PainSection.tsx
@@ -7,6 +7,9 @@ import LedgerScatter from "./LedgerScatter";
 
 const MotionBox = motion.create(Box);
 
+const AUTOPLAY_MS = 5000;
+const BRAND_MAROON = "#49082D";
+
 // Load-bearing word gets the accent color (upright, not italic).
 const cards = [
   {
@@ -59,51 +62,39 @@ function useIsDesktop(bp = 768) {
 
 export default function PainSection() {
   const [activeIdx, setActiveIdx] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const [inView, setInView] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
-  const hoveringRef = useRef(false);
-  const inViewRef = useRef(false);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isDesktop = useIsDesktop();
 
   const advance = useCallback(() => setActiveIdx((i) => (i + 1) % cards.length), []);
 
-  const stopTimer = useCallback(() => {
-    if (timerRef.current) {
-      clearInterval(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
-  const startTimer = useCallback(() => {
-    if (timerRef.current) return;
-    if (!inViewRef.current || hoveringRef.current) return;
-    timerRef.current = setInterval(() => {
-      setActiveIdx((i) => (i + 1) % cards.length);
-    }, 7000);
-  }, []);
+  // Autoplay timer. Restarts (via the useEffect dep list) whenever activeIdx
+  // changes, or when paused/inView flip, so the visible progress fill and the
+  // actual advance stay locked together.
+  useEffect(() => {
+    if (paused || !inView) return;
+    const t = setTimeout(advance, AUTOPLAY_MS);
+    return () => clearTimeout(t);
+  }, [activeIdx, paused, inView, advance]);
 
-  // Autoplay on visibility, pause on hover.
+  // Visibility gate.
   useEffect(() => {
     const el = wrapRef.current;
     if (!el) return;
     const io = new IntersectionObserver(
       (entries) => {
-        for (const ent of entries) {
-          inViewRef.current = ent.isIntersecting;
-          if (ent.isIntersecting) startTimer();
-          else stopTimer();
-        }
+        for (const ent of entries) setInView(ent.isIntersecting);
       },
       { threshold: 0.4 }
     );
     io.observe(el);
-    return () => {
-      io.disconnect();
-      stopTimer();
-    };
-  }, [startTimer, stopTimer]);
+    return () => io.disconnect();
+  }, []);
 
   const positions = isDesktop ? desktopPositions : mobilePositions;
   const counter = String(activeIdx + 1).padStart(2, "0");
+  const progressPlaying = inView && !paused;
 
   return (
     <Box
@@ -125,14 +116,8 @@ export default function PainSection() {
           role="group"
           aria-label="Four things ops teams tell us after they have tried to automate"
           onClick={advance}
-          onMouseEnter={() => {
-            hoveringRef.current = true;
-            stopTimer();
-          }}
-          onMouseLeave={() => {
-            hoveringRef.current = false;
-            startTimer();
-          }}
+          onMouseEnter={() => setPaused(true)}
+          onMouseLeave={() => setPaused(false)}
           onKeyDown={(e) => {
             if (e.key === "ArrowRight" || e.key === "ArrowLeft" || e.key === " " || e.key === "Enter") {
               e.preventDefault();
@@ -182,18 +167,45 @@ export default function PainSection() {
             >
               Running ops is difficult. Automating, doubly so.
             </Heading>
-            <Text
-              as="span"
-              fontFamily="mono"
-              fontSize="11px"
-              letterSpacing="0.16em"
-              textTransform="uppercase"
-              color="surface.page"
+            {/* Counter with a maroon fill sweeping behind the text over
+                AUTOPLAY_MS. Restarts on advance; pauses on hover/off-screen. */}
+            <Box
+              position="relative"
+              display="inline-block"
+              alignSelf="flex-start"
+              overflow="hidden"
+              px="6px"
+              py="3px"
               mt={2}
-              style={{ fontVariantNumeric: "tabular-nums" }}
             >
-              {counter} / 04
-            </Text>
+              <MotionBox
+                key={`${activeIdx}-${progressPlaying}`}
+                position="absolute"
+                top={0}
+                left={0}
+                bottom={0}
+                bg={BRAND_MAROON}
+                initial={{ width: "0%" }}
+                animate={{ width: progressPlaying ? "100%" : "0%" }}
+                transition={{
+                  duration: progressPlaying ? AUTOPLAY_MS / 1000 : 0,
+                  ease: "linear",
+                }}
+                style={{ zIndex: 0 }}
+              />
+              <Text
+                as="span"
+                position="relative"
+                fontFamily="mono"
+                fontSize="11px"
+                letterSpacing="0.16em"
+                textTransform="uppercase"
+                color="surface.page"
+                style={{ fontVariantNumeric: "tabular-nums", zIndex: 1 }}
+              >
+                {counter} / 04
+              </Text>
+            </Box>
           </Box>
 
           {/* Right column — perspective / deck */}

--- a/src/components/Landing/VerticalDemo.tsx
+++ b/src/components/Landing/VerticalDemo.tsx
@@ -1054,12 +1054,11 @@ export default function VerticalDemo({
             <Box
               flex="1"
               overflow="hidden"
-              // Center the goal stack vertically — in end-of-cycle states
-              // (all goals collapsed to their compact "done" form) a
-              // top-anchored stack left a large dead gap above the footer.
+              // Top-anchored so new goals stack downward instead of the whole
+              // list expanding from the middle.
               display="flex"
               flexDirection="column"
-              justifyContent="center"
+              justifyContent="flex-start"
               css={{
                 maskImage: "linear-gradient(to bottom, black 88%, transparent 100%)",
                 WebkitMaskImage: "linear-gradient(to bottom, black 88%, transparent 100%)",

--- a/src/components/Landing/VerticalsSection.tsx
+++ b/src/components/Landing/VerticalsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Container, Flex, Heading } from "@chakra-ui/react";
+import { Box, Container, Flex, Heading, Text } from "@chakra-ui/react";
 import { getEarlyAccess } from "@/lib/utils";
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import VerticalDemo from "./VerticalDemo";
@@ -40,6 +40,14 @@ const PROMPTS: Record<VerticalKey, string[]> = {
   ],
 };
 
+const DESCRIPTIONS: Record<VerticalKey, string> = {
+  freight: "Book carriers, chase quotes and catch surprise charges before they ever reach your invoice queue.",
+  procurement: "Raise POs and pay invoices only when the budget, the goods and the paperwork all agree.",
+  vendor: "Onboard new suppliers and confirm every bank-detail change on a second channel before money moves.",
+  hr: "Get new hires ready on day one and revoke every account the moment someone leaves.",
+  finance: "Close the month faster with automatic accruals, matched bank lines and variance flags you can trust.",
+};
+
 const CYCLE_INTERVAL = 4000;
 
 type FlatPrompt = {
@@ -68,6 +76,7 @@ export default function VerticalsSection() {
   const cycleTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const tabScrollerRef = useRef<HTMLDivElement | null>(null);
   const panelId = "verticals-tabpanel";
 
   // Mobile flat carousel: one row of ALL prompts across ALL tabs. The active
@@ -224,6 +233,21 @@ export default function VerticalsSection() {
     );
   }, [centeredFlatIdx, flatPrompts, isMobileViewport]);
 
+  // Keep the active pill scrolled into view within the pill row itself as
+  // the active tab changes (via swipe or pill tap). Never scrollIntoView —
+  // that would walk up and scroll the page too.
+  useEffect(() => {
+    if (!isMobileViewport) return;
+    const scroller = tabScrollerRef.current;
+    const idx = TAB_ITEMS.findIndex((t) => t.key === activeTab);
+    const btn = tabRefs.current[idx];
+    if (!scroller || !btn) return;
+    // Center the active pill in the scroller viewport when possible.
+    const target = btn.offsetLeft - (scroller.clientWidth - btn.clientWidth) / 2;
+    const clamped = Math.max(0, Math.min(target, scroller.scrollWidth - scroller.clientWidth));
+    scroller.scrollTo({ left: clamped, behavior: "smooth" });
+  }, [activeTab, isMobileViewport]);
+
   const handleTabClick = useCallback(
     (key: VerticalKey) => {
       handleUserInteraction();
@@ -333,17 +357,25 @@ export default function VerticalsSection() {
           Built for ops teams who want to be AI-first, not eventually.
         </Heading>
 
-        {/* Tabs — wrap on mobile too now; the pills are a readout of which
-            tab the carousel is currently on, not a separate scrolling axis.
-            zIndex bumped so the desktop ledger's outset halo (which pokes
-            leftward from the demo column) can't paint over the pills. */}
+        {/* Tabs — single swipeable row on mobile, wrapping row on desktop.
+            The pill row also mirrors which tab the carousel is currently
+            on: when the active tab changes (swipe or tap), the active pill
+            smooth-scrolls into view WITHIN this row only. zIndex bumped so
+            the desktop ledger's outset halo can't paint over the pills. */}
         <Box position="relative" zIndex={2} mb={{ base: 8, md: 14 }}>
           <Flex
+            ref={tabScrollerRef}
             role="tablist"
             aria-label="Industry verticals"
             gap={2}
             justifyContent="flex-start"
-            flexWrap="wrap"
+            flexWrap={{ base: "nowrap", md: "wrap" }}
+            overflowX={{ base: "auto", md: "visible" }}
+            css={{
+              scrollbarWidth: "none",
+              msOverflowStyle: "none",
+              "&::-webkit-scrollbar": { display: "none" },
+            }}
           >
             {TAB_ITEMS.map((item, idx) => (
               <Box
@@ -387,6 +419,17 @@ export default function VerticalsSection() {
               </Box>
             ))}
           </Flex>
+          {/* Edge fade hint — mobile only, to signal the row scrolls */}
+          <Box
+            display={{ base: "block", md: "none" }}
+            position="absolute"
+            top={0}
+            bottom={0}
+            right={0}
+            w="24px"
+            pointerEvents="none"
+            bgGradient="linear(to-r, transparent, ink.primary)"
+          />
         </Box>
 
         {/* Tab panel.
@@ -415,6 +458,15 @@ export default function VerticalsSection() {
             <Box
               display={{ base: "block", md: "none" }}
             >
+              <Text
+                color="rgba(255,255,255,0.7)"
+                fontSize={{ base: "md", md: "lg" }}
+                lineHeight="1.5"
+                fontWeight="400"
+                mb={4}
+              >
+                {DESCRIPTIONS[activeTab]}
+              </Text>
               <Box
                 ref={promptScrollerRef}
                 role="listbox"
@@ -496,6 +548,15 @@ export default function VerticalsSection() {
 
             {/* DESKTOP: text list */}
             <Box display={{ base: "none", md: "block" }} data-testid="verticals-desktop-list" role="listbox" aria-label="Prompts (desktop)">
+              <Text
+                color="rgba(255,255,255,0.7)"
+                fontSize={{ base: "md", md: "lg" }}
+                lineHeight="1.5"
+                fontWeight="400"
+                mb={4}
+              >
+                {DESCRIPTIONS[activeTab]}
+              </Text>
               {desktopPrompts.map((prompt, idx) => (
                 <Box
                   key={prompt}


### PR DESCRIPTION
## Summary
Recovers work that never made it into main after PR #57, plus a couple of new fixes.

**Animation anchors**
- Get section demos: `justify="center"` → `"flex-start"` on outer flex columns (ConnectDemo, RewindDemo, AuditDemo, UpdateDemo). Recovered from lost commit `3c03fce`.
- Verticals demo: same fix on the goal-stack Box in `VerticalDemo`. New.

**Pain section**
- Autoplay: 7s → 5s.
- Counter (`01 / 04`) now doubles as the timer: a maroon bar sweeps 0 → 100% width behind the digits over the 5s interval. Restarts on advance; pauses on hover / off-screen.

**Verticals section**
- Mobile pill row: single horizontal scrolling strip (was wrapping). Active pill smooth-scrolls into view within the row when the carousel changes tabs. Recovered from lost commit `68bd743`.
- One-sentence description of the active vertical between pills and prompt content, both breakpoints.

**LedgerScatter**
- Removed the printed-ledger numeral column (01–08) from every mount — it read as decorative filler.
- Dark preset now brightens cells (cream ink, lower max strength) instead of darkening them into a smudge. Recovered from lost commit `82f2737`.

## Test plan
- [x] `localhost:3000` — Get + Verticals demos stack downward
- [x] `localhost:3000` — Pain counter fills with maroon over 5s, restarts on advance, pauses on hover
- [x] `localhost:3000` — Verticals pills scroll horizontally on mobile; description line renders
- [x] `localhost:3000` — no numeral column anywhere; dark ledger sections brighten on cursor
- [ ] Vercel preview parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMPzodg3NR5uwpkEwGABdS